### PR TITLE
feat: modify Button atom, ButtonDiv molecule

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,32 +4,45 @@ import A from '@atom'
 import M from '@molecule'
 
 const buttonStyle = {
-  height: '10rem',
-  width: '20rem',
-  backgroundColor: 'red',
+  padding: '2rem',
+  backgroundColor: 'lightBlue',
+  hover: true,
+}
+
+const textStyle = {
+  color: 'red',
+  fontSize: '10rem',
 }
 
 const App = () => {
   return (
     <>
       <GlobalStyle />
-      <M.ButtonDiv buttonStyle={buttonStyle}>ddd</M.ButtonDiv>
+      <A.Text customStyle={{ color: 'red' }}>text</A.Text>
+      <A.Button customStyle={{ border: 'none' }}>A.Button</A.Button>
+      <M.ButtonDiv
+        buttonStyle={buttonStyle}
+        textStyle={textStyle}
+        onClick={() => {
+          alert('ButtonDiv Click')
+        }}
+      >
+        M.ButtonDiv
+      </M.ButtonDiv>
     </>
   )
 }
 
 const GlobalStyle = createGlobalStyle`
+  body {
+    height: 100vh;
+    width: 100vw;
+  }
   * {
     padding: 0px;
     margin: 0px;
-    height: 100vh;
-    width: 100vh;
     box-sizing: border-box;
     font-size: 62.5%;
-    margin: 0 auto;
-  }
-  p{
-    outline: none;
   }
 `
 

--- a/client/src/component/atom/Button.tsx
+++ b/client/src/component/atom/Button.tsx
@@ -12,7 +12,12 @@ const StyledButton = styled.button<ButtonType.StyleAttributes>`
   margin: ${({ margin }) => margin};
   padding: ${({ padding }) => padding};
   border-radius: ${({ rounded }) => (rounded ? 4 : 0)}px;
+  border: ${({ border }) => border};
   background-color: ${({ backgroundColor }) => color.get(backgroundColor)};
+  opacity: 0.8;
+  &:hover {
+    opacity: ${({ hover }) => hover && '1'};
+  }
 `
 
 export namespace ButtonType {
@@ -22,8 +27,10 @@ export namespace ButtonType {
     margin?: string
     padding?: string
     rounded?: boolean
+    border?: string
     backgroundColor?: string
     disabled?: boolean
+    hover?: boolean
   }
 
   export interface Props {
@@ -34,10 +41,12 @@ export namespace ButtonType {
 }
 
 const defaultStyle: ButtonType.StyleAttributes = {
-  height: '1rem',
-  width: '2rem',
+  height: 'auto',
+  width: 'auto',
+  border: '1px solid #000000',
   backgroundColor: 'grey',
   disabled: false,
+  hover: false,
 }
 
 const Button = ({
@@ -47,13 +56,15 @@ const Button = ({
 }: ButtonType.Props) => {
   return (
     <StyledButton
-      height={customStyle.height || '1rem'}
-      width={customStyle.width || '2rem'}
+      height={customStyle.height || 'auto'}
+      width={customStyle.width || 'auto'}
       margin={customStyle.margin}
       padding={customStyle.padding}
       rounded={customStyle.rounded}
+      border={customStyle.border || '1px solid #000000'}
       backgroundColor={customStyle.backgroundColor || 'grey'}
-      disabled={customStyle.disabled || false}
+      disabled={customStyle.disabled}
+      hover={customStyle.hover}
       onClick={onClick}
     >
       {children}

--- a/client/src/component/molecule/ButtonDiv.tsx
+++ b/client/src/component/molecule/ButtonDiv.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import A from '@atom'
-import { ButtonType } from '@atom/button'
-import { TextType } from '@atom/text'
+import { ButtonType } from '@atom/Button'
+import { TextType } from '@atom/Text'
 
 namespace ButtonDivType {
   export interface Props {
@@ -16,9 +16,10 @@ const ButtonDiv = ({
   buttonStyle,
   textStyle,
   children,
+  onClick,
 }: ButtonDivType.Props) => {
   return (
-    <A.Button customStyle={buttonStyle}>
+    <A.Button customStyle={buttonStyle} onClick={onClick}>
       <A.Text customStyle={textStyle}>{children}</A.Text>
     </A.Button>
   )


### PR DESCRIPTION
## Linked Issue
close #

## 공유할 사항 
- Button atom 컴포넌트 props 변경
  - **border** prop 추가
  - 사용 예시 ->  '1px solid black'
- ButtonDiv의 Text height이 길어졌던 이유 -> GlobalStyle의 * { height: 100vh } 때문이었음
  - css 오류 수정 : { height: 100vh, width: 100vw } 설정 body로 이동

## 논의할 사항 
- Button의 hover 처리 및 disabled 처리
