### PR TITLE
Feature/be/create message (#44)

### DIFF
--- a/client/src/component/molecule/ButtonDiv.tsx
+++ b/client/src/component/molecule/ButtonDiv.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import A from '@atom'
-import { ButtonType } from '@atom/button'
-import { TextType } from '@atom/text'
+import { ButtonType } from '@atom/Button'
+import { TextType } from '@atom/Text'
 
 namespace ButtonDivType {
   export interface Props {

--- a/server/src/controller/index.ts
+++ b/server/src/controller/index.ts
@@ -3,11 +3,12 @@ import userController from './user'
 import workspaceController from './workspace'
 import verifyUser from '../middleware/user.middleware'
 import threadController from './thread'
+import messageController from './message'
 
 const router = Router()
 
 router.use('/user', userController)
-
+router.use('/message', messageController)
 router.use(verifyUser)
 router.use('/workspace', workspaceController)
 router.use('/thread', threadController)

--- a/server/src/controller/index.ts
+++ b/server/src/controller/index.ts
@@ -8,8 +8,8 @@ import messageController from './message'
 const router = Router()
 
 router.use('/user', userController)
-router.use('/message', messageController)
 router.use(verifyUser)
+router.use('/message', messageController)
 router.use('/workspace', workspaceController)
 router.use('/thread', threadController)
 

--- a/server/src/controller/message/index.ts
+++ b/server/src/controller/message/index.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import messageController from './message.controller'
+
+const router = Router()
+
+router.post('/:id', messageController.createMessage)
+
+export default router

--- a/server/src/controller/message/message.controller.ts
+++ b/server/src/controller/message/message.controller.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express'
+import messageService from '../../service/message.service'
+
+const createMessage = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  console.log(req.param, req.body)
+  const { id: threadId } = req.params
+  const { content } = req.body
+  try {
+    const { code, json } = await messageService.createMessage({
+      threadId,
+      content,
+    })
+    return res.status(code).json(json)
+  } catch (error) {
+    return next(error)
+  }
+}
+
+export default { createMessage }

--- a/server/src/controller/message/message.controller.ts
+++ b/server/src/controller/message/message.controller.ts
@@ -6,13 +6,11 @@ const createMessage = async (
   res: Response,
   next: NextFunction,
 ) => {
-  console.log(req.param, req.body)
-  const { id: threadId } = req.params
-  const { content } = req.body
   try {
     const { code, json } = await messageService.createMessage({
-      threadId,
-      content,
+      userId: req.user.id,
+      threadId: Number(req.params.id),
+      content: req.body.content,
     })
     return res.status(code).json(json)
   } catch (error) {

--- a/server/src/controller/thread/thread.controller.ts
+++ b/server/src/controller/thread/thread.controller.ts
@@ -12,7 +12,7 @@ const createThread = async (
     const { code, json } = await threadService.createThread(newThreadData)
     return res.status(code).json(json)
   } catch (error) {
-    next(error)
+    return next(error)
   }
 }
 

--- a/server/src/middleware/user.middleware.ts
+++ b/server/src/middleware/user.middleware.ts
@@ -13,7 +13,7 @@ const verifyUser = (req: Request, res: Response, next: NextFunction) => {
     headers: { authorization },
   } = req
   if (!authorization) return res.send('unauthorized user')
-  const token = authorization.replace('bearer ', '')
+  const token = authorization.replace(/bearer /i, '')
   const { id, email, name } = jwt.checkToken(token) as UserInfo
   const isUser = checkUser({ id, email, name })
   if (!isUser) return res.send('unauthorized user')

--- a/server/src/model/message.model.ts
+++ b/server/src/model/message.model.ts
@@ -30,6 +30,7 @@ Message.init(
     isHead: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -2,7 +2,25 @@ import messageModel from '../model/message.model'
 import threadModel from '../model/thread.model'
 import { statusCode, resMessage } from '../util/constant'
 
-const createMessage = async (data: object) => {
+interface MessageType {
+  userId: number
+  threadId: number
+  content: string
+}
+
+const isValidNewData = ({ userId, threadId, content }: MessageType) => {
+  if (!userId || !threadId || !content || content === '') return false
+  if (userId < 1 || threadId < 1 || Number.isNaN(threadId)) return false
+  return true
+}
+
+const createMessage = async (data: MessageType) => {
+  console.log(data)
+  if (isValidNewData(data) === false)
+    return {
+      code: statusCode.BAD_REQUEST,
+      json: { success: true, message: resMessage.OUT_OF_VALUE },
+    }
   const userId = 1
   try {
     await messageModel.create({ ...data, userId })

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -1,0 +1,22 @@
+import messageModel from '../model/message.model'
+import threadModel from '../model/thread.model'
+import { statusCode, resMessage } from '../util/constant'
+
+const createMessage = async (data: object) => {
+  const userId = 1
+  try {
+    await messageModel.create({ ...data, userId })
+    return {
+      code: statusCode.CREATED,
+      json: { success: true },
+    }
+  } catch (error) {
+    console.log(error)
+    return {
+      code: statusCode.DB_ERROR,
+      json: { success: false, message: resMessage.DB_ERROR },
+    }
+  }
+}
+
+export default { createMessage }

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -10,6 +10,11 @@ basePath: /
 paths:
   $ref: './paths/_index.yaml'
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     Thread:
       type: object

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -12,6 +12,50 @@ paths:
 components:
   parameters:
   schemas:
+    Thread:
+      type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: integer
+        userId:
+          type: integer
+        channelId:
+          type: integer
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+        deletedAt:
+          type: string
+    Message:
+      type: object
+      required:
+        - id
+        - content
+        - isHead
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: integer
+        content:
+          type: string
+        isHead:
+          type: string
+        userId:
+          type: integer
+        threadId:
+          type: integer
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+        deletedAt:
+          type: string
     User:
       type: object
       required:

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -10,7 +10,6 @@ basePath: /
 paths:
   $ref: './paths/_index.yaml'
 components:
-  parameters:
   schemas:
     Thread:
       type: object

--- a/server/src/swagger/paths/_index.yaml
+++ b/server/src/swagger/paths/_index.yaml
@@ -2,3 +2,5 @@
   $ref: './user.yaml'
 /api/thread:
   $ref: './thread.yaml'
+/api/message/{id}:
+  $ref: './message.yaml'

--- a/server/src/swagger/paths/message.yaml
+++ b/server/src/swagger/paths/message.yaml
@@ -1,5 +1,7 @@
 post:
   summary: Create message
+  security:
+    - BearerAuth: []
   parameters:
     - in: path
       name: id

--- a/server/src/swagger/paths/message.yaml
+++ b/server/src/swagger/paths/message.yaml
@@ -1,0 +1,29 @@
+post:
+  summary: Create message
+  parameters:
+    - in: path
+      name: id
+      description: thread id
+      type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            content:
+              type: string
+  responses:
+    '201':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+    '500':
+      $ref: '../openapi.yaml#/components/responses/InternalServerError'
+    '600':
+      $ref: '../openapi.yaml#/components/responses/DBError'


### PR DESCRIPTION
## Linked Issue
close #44

## 공유할 사항 
- 파일이 많아보이지만 .... 파일만 많아요. swagger 때문에 더 많아 보일 뿐입니다.
- swagger에 security 옵션을 추가했습니다. api 를 작성할 때 아래와 같이 `security: -BearerAuth: []` 만 추가해주면 됩니다.
  ```yaml
  post: 
    summary: Create message
    security:
      - BearerAuth: []
    parameters:
    ...
  ```
  - 사용 (토큰 입력 시 나오는 화면)
    ![image](https://user-images.githubusercontent.com/48546343/100129009-546f9a80-2ec4-11eb-9fd1-df668f51ab29.png)



## 논의할 사항 
- message 테이블에 존재하는 foreignKey(`threadId, userId`)의 존재 여부를 sequelize에서 검사해주는 줄 알았는데, 존재하지 않는 threadId를 넣어도 잘 동작합니다. 하나의 `create` 함수를 사용해서 foreignKey 들의 존재 여부를 파악할 수 있나요? 아니면 그전에 `find`를 써서 존재 여부를 파악해야 하나요 ?!
- token 만료 시간이 1일이 맞나요? 굉장히 금방 만료됩니다요
