### PR TITLE
Feature/fe/routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react'
-import { Switch, Route, useHistory } from 'react-router-dom'
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  useHistory,
+} from 'react-router-dom'
 import { createGlobalStyle } from 'styled-components'
 import myAxios from '@util/myAxios'
 import LoginPage from '@page/User/LoginPage'
@@ -54,10 +59,12 @@ const App = () => {
   return (
     <>
       <GlobalStyle />
-      <Switch>
-        <Route exact path="/" component={WorkspacePage} />
-        <Route exact path="/login" component={LoginPage} />
-      </Switch>
+      <Router>
+        <Switch>
+          <Route exact path="/" component={WorkspacePage} />
+          <Route exact path="/login" component={LoginPage} />
+        </Switch>
+      </Router>
     </>
   )
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
     compress: false,
     hot: true,
     port: 8000,
+    historyApiFallback: true
   },
 
   plugins: [


### PR DESCRIPTION
## Linked Issue
close #

## 공유할 사항 
- BrowserRouter 사용
- 링크를 직접 입력해 들어가는 경우 서버 라우트를 한번 타게 됨. 이 경우 서버쪽에서 리액트 앱으로 연결시켜 줘야 함. 
- 개발 서버 : historyApiFallback 설정 추가 -> 404 에러 해소
  - 어떤 요청으로 들어오던 client app으로 연결되도록 설정

## 논의할 사항 
- 실제 서버에서도 리액트 앱 연결 작업 필요
