### PR TITLE
Feature/fe/channel header

### DIFF
--- a/client/src/component/atom/ModalWrapper/ModalWrapper.tsx
+++ b/client/src/component/atom/ModalWrapper/ModalWrapper.tsx
@@ -22,6 +22,7 @@ const ModalWrapper = ({
     borderRadius={customStyle.borderRadius}
     boxShadow={customStyle.boxShadow}
     backgroundColor={customStyle.backgroundColor}
+    overflow={customStyle.overflow}
     hidden={hidden}
   >
     {children}
@@ -58,7 +59,7 @@ const StyledModalWrapper = styled.div<ModalWrapperType.StyleAttributes>`
   background-color: ${({ backgroundColor }) =>
     backgroundColor ? colors.get(backgroundColor) : ''};
   z-index: ${({ zIndex }) => zIndex || defaultStyle.zIndex};
-  overflow: auto;
+  overflow: ${({ overflow }) => overflow};
   display: ${({ hidden }) => (hidden ? 'none' : 'block')};
 `
 

--- a/client/src/component/atom/ModalWrapper/index.ts
+++ b/client/src/component/atom/ModalWrapper/index.ts
@@ -17,6 +17,7 @@ export namespace ModalWrapperType {
     borderRadius?: string
     boxShadow?: string
     backgroundColor?: string
+    overflow?: string
   }
 
   export interface Props {

--- a/client/src/component/atom/Text/Text.tsx
+++ b/client/src/component/atom/Text/Text.tsx
@@ -18,6 +18,7 @@ const Text = ({
     fontWeight={customStyle.fontWeight}
     display={customStyle.display}
     hoverColor={customStyle.hoverColor}
+    cursor={customStyle.cursor}
     onClick={onClick}
   >
     {children}
@@ -34,7 +35,7 @@ const defaultStyle: TextType.StyleAttributes = {
   display: 'inline',
 }
 
-const StyledText = styled.p<TextType.StyleAttributes>`
+const StyledText = styled.span<TextType.StyleAttributes>`
   margin: ${({ margin }) => margin};
   padding: ${({ padding }) => padding};
   width: ${({ width }) => width};

--- a/client/src/component/organism/Avatar/Avatar.stories.tsx
+++ b/client/src/component/organism/Avatar/Avatar.stories.tsx
@@ -15,16 +15,28 @@ export const avatar = () => {
       'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
   }
 
+  const handleMessageButtonClick = () => alert(`DM to ${user.name}`)
+
   return (
     <>
       <div>SMALL size & clickable</div>
-      <Avatar user={user} size="SMALL" clickable />
+      <Avatar
+        user={user}
+        size="SMALL"
+        clickable
+        onMessageButtonClick={handleMessageButtonClick}
+      />
       <hr />
       <div>MEDIUM size & clickable false</div>
       <Avatar user={user} size="MEDIUM" />
       <hr />
       <div>BIG size & clickable</div>
-      <Avatar user={user} size="BIG" clickable />
+      <Avatar
+        user={user}
+        size="BIG"
+        clickable
+        onMessageButtonClick={handleMessageButtonClick}
+      />
     </>
   )
 }

--- a/client/src/component/organism/Avatar/Avatar.stories.tsx
+++ b/client/src/component/organism/Avatar/Avatar.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import Avatar from '.'
+
+export default {
+  title: 'Organism/Avatar',
+  component: Avatar,
+}
+
+export const avatar = () => {
+  const user = {
+    id: 3,
+    email: 'caribou503@gmail.com',
+    name: 'Seo Young Kim',
+    profileImageUrl:
+      'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+  }
+
+  return (
+    <>
+      <div>SMALL size & clickable</div>
+      <Avatar user={user} size="SMALL" clickable />
+      <hr />
+      <div>MEDIUM size & clickable false</div>
+      <Avatar user={user} size="MEDIUM" />
+      <hr />
+      <div>BIG size & clickable</div>
+      <Avatar user={user} size="BIG" clickable />
+    </>
+  )
+}
+
+avatar.story = {
+  name: 'Default',
+}

--- a/client/src/component/organism/Avatar/Avatar.style.ts
+++ b/client/src/component/organism/Avatar/Avatar.style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  display: inline-block;
+  cursor: pointer;
+  position: relative;
+`
+
+export default {
+  Wrapper,
+}

--- a/client/src/component/organism/Avatar/Avatar.tsx
+++ b/client/src/component/organism/Avatar/Avatar.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import A from '@atom'
+import O from '@organism'
+// import myIcon from '@constant/icon'
+import { ImageType } from '@atom/Image'
+import { AvatarProps } from '.'
+
+import Styled from './Avatar.style'
+
+const Avatar = ({ user, size, clickable }: AvatarProps) => {
+  const { id, email, name, profileImageUrl } = user
+  const [profileModalVisible, setProfileModalVisible] = useState(false)
+
+  // eslint-disable-next-line no-nested-ternary
+  const squarePx = size === 'BIG' ? '36px' : size === 'MEDIUM' ? '24px' : '20px'
+
+  const avatarImageStyle: ImageType.StyleAttributes = {
+    height: squarePx,
+    width: squarePx,
+    margin: '0',
+    padding: '0',
+    radius: '4px',
+  }
+
+  const handleAvatarClick = () => {
+    if (clickable) setProfileModalVisible(true)
+  }
+  const handleProfileModalClose = () => setProfileModalVisible(false)
+
+  return (
+    <Styled.Wrapper>
+      <A.Image
+        customStyle={avatarImageStyle}
+        url={profileImageUrl}
+        onClick={handleAvatarClick}
+      />
+    </Styled.Wrapper>
+  )
+}
+
+Avatar.defaultProps = {}
+
+export default Avatar

--- a/client/src/component/organism/Avatar/Avatar.tsx
+++ b/client/src/component/organism/Avatar/Avatar.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react'
 import A from '@atom'
 import O from '@organism'
-// import myIcon from '@constant/icon'
 import { ImageType } from '@atom/Image'
 import { AvatarProps } from '.'
 
 import Styled from './Avatar.style'
 
-const Avatar = ({ user, size, clickable }: AvatarProps) => {
+const Avatar = ({
+  user,
+  size,
+  clickable,
+  onMessageButtonClick,
+}: AvatarProps) => {
   const { id, email, name, profileImageUrl } = user
   const [profileModalVisible, setProfileModalVisible] = useState(false)
 
@@ -34,6 +38,14 @@ const Avatar = ({ user, size, clickable }: AvatarProps) => {
         url={profileImageUrl}
         onClick={handleAvatarClick}
       />
+      {profileModalVisible && (
+        <O.UserProfileModal
+          user={user}
+          modalAttributes={{ position: 'absolute', left: '120%', top: '0' }}
+          onMessageButtonClick={onMessageButtonClick}
+          onClose={handleProfileModalClose}
+        />
+      )}
     </Styled.Wrapper>
   )
 }

--- a/client/src/component/organism/Avatar/index.ts
+++ b/client/src/component/organism/Avatar/index.ts
@@ -1,0 +1,8 @@
+export { default } from './Avatar'
+
+export interface AvatarProps {
+  user: object
+  size: 'SMALL' | 'MEDIUM' | 'BIG'
+  clickable: boolean
+  // onClick?: () => void
+}

--- a/client/src/component/organism/Avatar/index.ts
+++ b/client/src/component/organism/Avatar/index.ts
@@ -3,6 +3,6 @@ export { default } from './Avatar'
 export interface AvatarProps {
   user: object
   size: 'SMALL' | 'MEDIUM' | 'BIG'
-  clickable: boolean
-  // onClick?: () => void
+  clickable?: boolean
+  onMessageButtonClick?: () => void
 }

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.stories.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.stories.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import ChannelHeader from '.'
+
+export default {
+  title: 'Organism/ChannelHeader',
+  component: ChannelHeader,
+}
+
+export const channelHeader = () => {
+  const publicChannel = {
+    id: 1,
+    type: 'PUBLIC',
+    name: 'slack-clone',
+    user: [
+      {
+        id: 1,
+        email: 'dlgkswn885@korea.ac.kr',
+        name: '‍이한주[ 학부재학 / 산업경영공학부 ]',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-N1Pn-Or52MM/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucn7DRZcFBqsGNFc9Z5LUf8hGZRi5g/s96-c/photo.jpg',
+      },
+      {
+        id: 2,
+        email: 'ihanju95@gmail.com',
+        name: '이두주',
+        profileImageUrl:
+          'https://lh3.googleusercontent.com/-VDkRdj9PpUo/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucnTBFod0S-59xYDXy2Y5oG8kAFYnA/s96-c/photo.jpg',
+      },
+      {
+        id: 3,
+        email: 'caribou503@gmail.com',
+        name: 'Seo Young Kim',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+      },
+    ],
+  }
+
+  const privateChannel = {
+    id: 2,
+    type: 'PRIVATE',
+    name: 'slack-clone-private-channel',
+    user: [
+      {
+        id: 1,
+        email: 'dlgkswn885@korea.ac.kr',
+        name: '‍이한주[ 학부재학 / 산업경영공학부 ]',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-N1Pn-Or52MM/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucn7DRZcFBqsGNFc9Z5LUf8hGZRi5g/s96-c/photo.jpg',
+      },
+    ],
+  }
+
+  return (
+    <>
+      <div>Public channel</div>
+      <ChannelHeader channel={publicChannel} />
+
+      <hr />
+      <div>Private channel</div>
+      <ChannelHeader channel={privateChannel} />
+    </>
+  )
+}
+
+channelHeader.story = {
+  name: 'Default',
+}

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.style.ts
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.style.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  border: 1px solid lightgrey;
+  padding: 10px 20px;
+`
+
+const LeftWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const RightWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+`
+
+export default {
+  Wrapper,
+  LeftWrapper,
+  RightWrapper,
+}

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import A from '@atom'
+import M from '@molecule'
+import O from '@organism'
+import myIcon from '@constant/icon'
+import { ButtonType } from '@atom/Button'
+
+import { ChannelHeaderProps } from '.'
+
+import Styled from './ChannelHeader.style'
+
+const ChannelHeader = ({ channel }: ChannelHeaderProps) => {
+  const { id, name, type, user } = channel // channel info
+
+  const [memberListModalVisible, setMemberListModalVisible] = useState(false)
+  const [addUserModalVisible, setAddUserModalVisible] = useState(false)
+
+  /** modal open/close handler */
+  const handleMemeberListButtonClick = () => setMemberListModalVisible(true)
+  const handleMemberListModalClose = () => setMemberListModalVisible(false)
+
+  const handleAddUserButtonClick = () => setAddUserModalVisible(true)
+  const handleAddUserModalClose = () => setAddUserModalVisible(false)
+
+  const handleStarButtonClick = () => alert('channel - section')
+  const handleInfoButtonClick = () => alert('show detailed info')
+
+  return (
+    <Styled.Wrapper>
+      <Styled.LeftWrapper>
+        <A.Icon icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock} />
+        <A.Text
+          customStyle={{
+            fontWeight: 'bold',
+            cursor: 'pointer',
+            margin: '0 0 0 8px',
+          }}
+          onClick={handleInfoButtonClick}
+        >
+          {name}
+        </A.Text>
+        <A.Button onClick={handleStarButtonClick} customStyle={buttonStyle}>
+          <A.Icon icon={myIcon.star} />
+        </A.Button>
+      </Styled.LeftWrapper>
+
+      <Styled.RightWrapper>
+        <div>member prev</div>
+        <A.Button onClick={handleAddUserButtonClick} customStyle={buttonStyle}>
+          <A.Icon icon={myIcon.addUser} />
+        </A.Button>
+        <A.Button onClick={handleInfoButtonClick} customStyle={buttonStyle}>
+          <A.Icon icon={myIcon.info} />
+        </A.Button>
+      </Styled.RightWrapper>
+
+      {/* {memberListModalVisible && (
+        <O.MemberListModal
+          channel={channel}
+          modalAttributes={{ position: 'fixed', left: '50%', top: '50%' }}
+          onClose={handleMemberListModalClose}
+        />
+      )}
+      {addUserModalVisible && (
+        <O.AddUserModal
+          channel={channel}
+          modalAttributes={{ position: 'fixed', left: '50%', top: '50%' }}
+          onClose={handleAddUserModalClose}
+        />
+      )} */}
+    </Styled.Wrapper>
+  )
+}
+
+ChannelHeader.defaultProps = {}
+
+const buttonStyle: ButtonType.StyleAttributes = {
+  hoverBackgroundColor: 'whiteHover',
+  width: '2rem',
+  height: '1.9rem',
+  margin: '2px',
+}
+
+export default ChannelHeader

--- a/client/src/component/organism/ChannelHeader/index.ts
+++ b/client/src/component/organism/ChannelHeader/index.ts
@@ -1,0 +1,5 @@
+export { default } from './ChannelHeader'
+
+export interface ChannelHeaderProps {
+  channel: object // id, type, name, user[]
+}

--- a/client/src/component/organism/UserProfileModal/UserProfileModal.stories.tsx
+++ b/client/src/component/organism/UserProfileModal/UserProfileModal.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import UserProfileModal from '.'
+
+export default {
+  title: 'Organism/UserProfileModal',
+  component: UserProfileModal,
+}
+
+export const userProfileModal = () => {
+  const user = {
+    id: 3,
+    email: 'caribou503@gmail.com',
+    name: 'Seo Young Kim',
+    profileImageUrl:
+      'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+  }
+  const handleMessageButtonClick = () => alert(`DM !`)
+
+  return (
+    <UserProfileModal
+      user={user}
+      onMessageButtonClick={handleMessageButtonClick}
+    />
+  )
+}

--- a/client/src/component/organism/UserProfileModal/UserProfileModal.style.ts
+++ b/client/src/component/organism/UserProfileModal/UserProfileModal.style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const BottomWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 17px;
+`
+
+export default {
+  Wrapper,
+  BottomWrapper,
+}

--- a/client/src/component/organism/UserProfileModal/UserProfileModal.tsx
+++ b/client/src/component/organism/UserProfileModal/UserProfileModal.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import A from '@atom'
+import M from '@molecule'
+import { TextType } from '@atom/Text'
+import { ButtonType } from '@atom/Button'
+import { ModalWrapperType } from '@atom/ModalWrapper'
+import { ImageType } from '@atom/Image'
+import { UserProfileModalProps } from '.'
+import Styled from './UserProfileModal.style'
+
+const UserProfileModal = ({
+  user,
+  modalAttributes,
+  onMessageButtonClick,
+  onClose,
+}: UserProfileModalProps) => {
+  const { id, email, name, profileImageUrl } = user
+
+  return (
+    <M.Modal
+      modalWrapperStyle={{ ...modalWrapperStyle, ...modalAttributes }}
+      disableCloseButton
+      onClose={onClose}
+    >
+      <Styled.Wrapper>
+        <A.Image customStyle={profileImageStyle} url={profileImageUrl} />
+        <Styled.BottomWrapper>
+          <A.Text customStyle={nameTextStyle}>{name}</A.Text>
+          <A.Text customStyle={emailTextStyle}>{email}</A.Text>
+          <M.ButtonDiv
+            buttonStyle={messageButtonStyle}
+            onClick={onMessageButtonClick}
+          >
+            Message
+          </M.ButtonDiv>
+        </Styled.BottomWrapper>
+      </Styled.Wrapper>
+    </M.Modal>
+  )
+}
+
+const modalWrapperStyle: ModalWrapperType.StyleAttributes = {
+  width: 'auto',
+  padding: '0',
+  backgroundColor: 'white',
+  border: '1px solid lightGrey',
+  borderRadius: '8px',
+  overflow: 'hidden',
+}
+
+const profileImageStyle: ImageType.StyleAttributes = {
+  width: '300px',
+  height: '300px',
+  radius: '0',
+}
+
+const messageButtonStyle: ButtonType.StyleAttributes = {
+  border: '1px solid lightgrey',
+  hoverBackgroundColor: 'whiteGrey',
+}
+
+const nameTextStyle: TextType.StyleAttributes = {
+  fontSize: '20px',
+  fontWeight: 'bold',
+  margin: '3px 0',
+}
+
+const emailTextStyle: TextType.StyleAttributes = {
+  fontSize: '14.5px',
+  color: 'blue',
+  margin: '0 0 15px 0',
+}
+
+export default UserProfileModal

--- a/client/src/component/organism/UserProfileModal/index.ts
+++ b/client/src/component/organism/UserProfileModal/index.ts
@@ -1,0 +1,10 @@
+import { ModalWrapperType } from '@atom/ModalWrapper'
+
+export { default } from './UserProfileModal'
+
+export interface UserProfileModalProps {
+  user: object
+  modalAttributes?: ModalWrapperType.StyleAttributes
+  onMessageButtonClick?: () => void
+  onClose?: () => void
+}

--- a/client/src/component/organism/index.ts
+++ b/client/src/component/organism/index.ts
@@ -1,8 +1,21 @@
 import Header from './Header'
 import MessageCard from './MessageCard'
 import MessageEditor from './MessageEditor'
+import ActionBar from './ActionBar'
 import MessageActionsMenu from './MessageActionsMenu'
 import ReactionPicker from './ReactionPicker'
+import UserProfileModal from './UserProfileModal'
+import Avatar from './Avatar'
+import ChannelHeader from './ChannelHeader'
 
-export default { MessageCard, MessageEditor, Header, MessageActionsMenu, ReactionPicker }
-
+export default {
+  Header,
+  MessageCard,
+  MessageEditor,
+  ActionBar,
+  MessageActionsMenu,
+  ReactionPicker,
+  UserProfileModal,
+  Avatar,
+  ChannelHeader,
+}

--- a/client/src/constant/icon.ts
+++ b/client/src/constant/icon.ts
@@ -12,6 +12,11 @@ import {
   faLaugh,
   faComment,
   faEllipsisV,
+  faStar,
+  faUserPlus,
+  faLock,
+  faHashtag,
+  faInfo,
 } from '@fortawesome/free-solid-svg-icons'
 
 const myIcon = {
@@ -28,6 +33,11 @@ const myIcon = {
   laughEmoji: faLaugh,
   comment: faComment,
   ellipsis: faEllipsisV,
+  star: faStar,
+  addUser: faUserPlus,
+  lock: faLock,
+  hashtag: faHashtag,
+  info: faInfo,
 }
 
 export default myIcon


### PR DESCRIPTION
## Linked Issue
close #108 
related #109, #54

## 공유할 사항 
- Thread, Message, DM, Header 등에서 재사용 될 수 있는 Avatar organism 컴포넌트를 구현했습니다.
  - user 객체를 넘겨주어 사용합니다.
  - SMALL, MEDIUM, BIG 세가지 사이즈 중 선택 가능합니다.
  - clickable이 true일 시 Avatar 컴포넌트를 클릭하면 UserProfileModal이 뜹니다. (clickable 값을 주지 않을 시 동작 X)
  - 해당 유저가 온라인 상태(active? online? 용어 뭐로 할지 고민중 추천바람)인지 판단하기 위한 뱃지(초록색 버튼 모양) UI를 추가할 예정입니다.
  - UserProfileModal에 전달하기 위한 onMessageButtonClick props를 가집니다.
<img width="186" alt="스크린샷 2020-11-28 오전 8 39 49" src="https://user-images.githubusercontent.com/57661699/100489060-5b610c00-3155-11eb-8df9-d33c3abcdfe9.png">

- Avatar에서 사용되는 UserProfileModal organism 컴포넌트를 구현했습니다.
  - Message Button을 클릭하면 DM 기능을 사용할 수 있도록 구현해야 합니다.
  - Avatar와 마찬가지로 온라인 상태 여부를 판단하여 이름 옆에 뱃지를 표시하도록 구현할 예정입니다.
<img width="338" alt="스크린샷 2020-11-28 오전 8 39 40" src="https://user-images.githubusercontent.com/57661699/100489057-57cd8500-3155-11eb-863d-df8a581542b3.png">

- ChannelHeader organism 컴포넌트를 구현했습니다.
  - 큰 레이아웃만 잡아둔 상태입니다. 
<img width="692" alt="스크린샷 2020-11-28 오전 8 40 56" src="https://user-images.githubusercontent.com/57661699/100489075-7895da80-3155-11eb-954b-07a67828de8f.png">


## 논의할 사항 
- 
