### PR TITLE
Feature/fe/channel header + MemberListModal (#54, #55)

### DIFF
--- a/client/src/component/atom/Image/Image.tsx
+++ b/client/src/component/atom/Image/Image.tsx
@@ -16,6 +16,8 @@ function Image({
       padding={customStyle.padding}
       radius={customStyle.radius}
       cursor={customStyle.cursor}
+      border={customStyle.border}
+      zIndex={customStyle.zIndex}
       onClick={onClick}
       src={url}
     />
@@ -41,6 +43,8 @@ const StyledImage = styled.img<ImageType.StyleAttributes>`
   margin: ${({ margin }) => margin};
   padding: ${({ padding }) => padding};
   border-radius: ${({ radius }) => radius || '4px'};
+  border: ${({ border }) => border};
+  z-index: ${({ zIndex }) => zIndex};
   cursor: ${({ cursor }) => cursor || 'pointer'};
 `
 

--- a/client/src/component/atom/Image/index.ts
+++ b/client/src/component/atom/Image/index.ts
@@ -8,6 +8,8 @@ export namespace ImageType {
     padding?: string
     radius?: string
     cursor?: string
+    border?: string
+    zIndex?: number
   }
 
   export interface Props {

--- a/client/src/component/atom/Input/Input.tsx
+++ b/client/src/component/atom/Input/Input.tsx
@@ -6,19 +6,25 @@ import { InputType } from '.'
 const Input = ({
   customStyle = defaultStyle,
   value,
+  placeholder,
   onChange,
 }: InputType.Props) => {
   return (
     <StyledInput
       height={customStyle.height}
       width={customStyle.width}
+      minHeight={customStyle.minHeight}
       margin={customStyle.margin}
       padding={customStyle.padding}
       border={customStyle.border}
       borderRadius={customStyle.borderRadius}
       backgroundColor={customStyle.backgroundColor}
+      fontSize={customStyle.fontSize}
+      overflow={customStyle.overflow}
+      outline={customStyle.outline}
       onChange={onChange}
       value={value}
+      placeholder={placeholder}
     />
   )
 }

--- a/client/src/component/atom/Input/index.ts
+++ b/client/src/component/atom/Input/index.ts
@@ -1,4 +1,4 @@
-import { ReactChild } from 'react'
+import React from 'react'
 
 export { default } from './Input'
 
@@ -21,6 +21,7 @@ export namespace InputType {
   export interface Props {
     customStyle?: StyleAttributes
     value?: string
+    placeholder?: string
     onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   }
 }

--- a/client/src/component/atom/index.ts
+++ b/client/src/component/atom/index.ts
@@ -4,5 +4,6 @@ import Text from './Text'
 import Icon from './Icon'
 import Overlay from './Overlay'
 import ModalWrapper from './ModalWrapper'
+import Input from './Input'
 
-export default { Button, Image, Text, Icon, Overlay, ModalWrapper }
+export default { Button, Image, Text, Icon, Overlay, ModalWrapper, Input }

--- a/client/src/component/molecule/Modal/Modal.tsx
+++ b/client/src/component/molecule/Modal/Modal.tsx
@@ -9,6 +9,7 @@ const Modal = ({
   modalWrapperStyle,
   children,
   disableCloseButton,
+  fixed,
   onClose,
 }: ModalProps) => {
   const [hidden, setHidden] = useState(false)
@@ -16,6 +17,11 @@ const Modal = ({
   const handleModalClose = (): void => {
     if (onClose) onClose()
     setHidden(true)
+  }
+
+  const modalBaseStyle: React.CSSProperties = {
+    position: fixed ? 'fixed' : 'inherit',
+    zIndex: 100,
   }
 
   const closeButton = (
@@ -36,7 +42,7 @@ const Modal = ({
   )
 
   return (
-    <div hidden={hidden}>
+    <div hidden={hidden} style={modalBaseStyle}>
       <A.Overlay customStyle={overlayStyle} onClick={handleModalClose} />
       <A.ModalWrapper customStyle={modalWrapperStyle}>
         <>

--- a/client/src/component/molecule/Modal/index.ts
+++ b/client/src/component/molecule/Modal/index.ts
@@ -9,5 +9,6 @@ export interface ModalProps {
   modalWrapperStyle?: ModalWrapperType.StyleAttributes
   children?: ReactChild
   disableCloseButton?: boolean
+  fixed?: boolean
   onClose?: () => void
 }

--- a/client/src/component/organism/Avatar/Avatar.tsx
+++ b/client/src/component/organism/Avatar/Avatar.tsx
@@ -10,6 +10,7 @@ const Avatar = ({
   user,
   size,
   clickable,
+  avatarImageStyle,
   onMessageButtonClick,
 }: AvatarProps) => {
   const { id, email, name, profileImageUrl } = user
@@ -18,7 +19,7 @@ const Avatar = ({
   // eslint-disable-next-line no-nested-ternary
   const squarePx = size === 'BIG' ? '36px' : size === 'MEDIUM' ? '24px' : '20px'
 
-  const avatarImageStyle: ImageType.StyleAttributes = {
+  const defaultAvatarImageStyle: ImageType.StyleAttributes = {
     height: squarePx,
     width: squarePx,
     margin: '0',
@@ -34,7 +35,7 @@ const Avatar = ({
   return (
     <Styled.Wrapper>
       <A.Image
-        customStyle={avatarImageStyle}
+        customStyle={{ ...defaultAvatarImageStyle, ...avatarImageStyle }}
         url={profileImageUrl}
         onClick={handleAvatarClick}
       />

--- a/client/src/component/organism/Avatar/index.ts
+++ b/client/src/component/organism/Avatar/index.ts
@@ -1,8 +1,11 @@
+import { ImageType } from '@atom/Image'
+
 export { default } from './Avatar'
 
 export interface AvatarProps {
   user: object
   size: 'SMALL' | 'MEDIUM' | 'BIG'
   clickable?: boolean
+  avatarImageStyle?: ImageType.StyleAttributes
   onMessageButtonClick?: () => void
 }

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.style.ts
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import color from '@constant/color'
 
 const Wrapper = styled.div`
   display: flex;
@@ -18,8 +19,16 @@ const RightWrapper = styled.div`
   align-items: center;
 `
 
+const MemberCountWrapper = styled.div`
+  width: 1.5rem;
+  &:hover {
+    background-color: ${color.get('whiteHover')};
+  }
+`
+
 export default {
   Wrapper,
   LeftWrapper,
   RightWrapper,
+  MemberCountWrapper,
 }

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
@@ -4,6 +4,7 @@ import O from '@organism'
 import myIcon from '@constant/icon'
 import { ButtonType } from '@atom/Button'
 import { ImageType } from '@atom/Image'
+import { TextType } from '@atom/Text'
 import { ChannelHeaderProps } from '.'
 
 import Styled from './ChannelHeader.style'
@@ -30,11 +31,7 @@ const ChannelHeader = ({ channel }: ChannelHeaderProps) => {
       <Styled.LeftWrapper>
         <A.Icon icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock} />
         <A.Text
-          customStyle={{
-            fontWeight: 'bold',
-            cursor: 'pointer',
-            margin: '0 0 0 8px',
-          }}
+          customStyle={channelNameTextStyle}
           onClick={handleInfoButtonClick}
         >
           {name}
@@ -108,6 +105,12 @@ const memberListButtonStyle: ButtonType.StyleAttributes = {
 const memberAvatarStyle: ImageType.StyleAttributes = {
   border: '2px solid white',
   margin: '0 0 0 -5px',
+}
+
+const channelNameTextStyle: TextType.StyleAttributes = {
+  fontWeight: 'bold',
+  cursor: 'pointer',
+  margin: '0 0 0 8px',
 }
 
 export default ChannelHeader

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
@@ -4,13 +4,14 @@ import M from '@molecule'
 import O from '@organism'
 import myIcon from '@constant/icon'
 import { ButtonType } from '@atom/Button'
-
+import { ImageType } from '@atom/Image'
 import { ChannelHeaderProps } from '.'
 
 import Styled from './ChannelHeader.style'
 
 const ChannelHeader = ({ channel }: ChannelHeaderProps) => {
-  const { id, name, type, user } = channel // channel info
+  const { id, name, type, user: members } = channel
+  const MEMBER_PROFILE_NUMBER: number = 3
 
   const [memberListModalVisible, setMemberListModalVisible] = useState(false)
   const [addUserModalVisible, setAddUserModalVisible] = useState(false)
@@ -45,7 +46,26 @@ const ChannelHeader = ({ channel }: ChannelHeaderProps) => {
       </Styled.LeftWrapper>
 
       <Styled.RightWrapper>
-        <div>member prev</div>
+        <A.Button
+          onClick={handleMemeberListButtonClick}
+          customStyle={memberListButtonStyle}
+        >
+          <>
+            {members
+              .filter((user, idx) => idx < MEMBER_PROFILE_NUMBER)
+              .map((user) => (
+                <O.Avatar
+                  user={user}
+                  size="SMALL"
+                  avatarImageStyle={memberAvatarStyle}
+                />
+              ))}
+            <Styled.MemberCountWrapper>
+              {members.length}
+            </Styled.MemberCountWrapper>
+          </>
+        </A.Button>
+
         <A.Button onClick={handleAddUserButtonClick} customStyle={buttonStyle}>
           <A.Icon icon={myIcon.addUser} />
         </A.Button>
@@ -60,8 +80,8 @@ const ChannelHeader = ({ channel }: ChannelHeaderProps) => {
           modalAttributes={{ position: 'fixed', left: '50%', top: '50%' }}
           onClose={handleMemberListModalClose}
         />
-      )}
-      {addUserModalVisible && (
+      )} */}
+      {/* {addUserModalVisible && (
         <O.AddUserModal
           channel={channel}
           modalAttributes={{ position: 'fixed', left: '50%', top: '50%' }}
@@ -79,6 +99,17 @@ const buttonStyle: ButtonType.StyleAttributes = {
   width: '2rem',
   height: '1.9rem',
   margin: '2px',
+}
+
+const memberListButtonStyle: ButtonType.StyleAttributes = {
+  hoverBackgroundColor: 'whiteHover',
+  height: '1.9rem',
+  margin: '2px',
+}
+
+const memberAvatarStyle: ImageType.StyleAttributes = {
+  border: '2px solid white',
+  margin: '0 0 0 -5px',
 }
 
 export default ChannelHeader

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import A from '@atom'
-import M from '@molecule'
 import O from '@organism'
 import myIcon from '@constant/icon'
 import { ButtonType } from '@atom/Button'
@@ -74,13 +73,12 @@ const ChannelHeader = ({ channel }: ChannelHeaderProps) => {
         </A.Button>
       </Styled.RightWrapper>
 
-      {/* {memberListModalVisible && (
+      {memberListModalVisible && (
         <O.MemberListModal
           channel={channel}
-          modalAttributes={{ position: 'fixed', left: '50%', top: '50%' }}
           onClose={handleMemberListModalClose}
         />
-      )} */}
+      )}
       {/* {addUserModalVisible && (
         <O.AddUserModal
           channel={channel}

--- a/client/src/component/organism/ChannelHeader/index.ts
+++ b/client/src/component/organism/ChannelHeader/index.ts
@@ -1,7 +1,7 @@
 export { default } from './ChannelHeader'
 
 export interface ChannelHeaderProps {
-  channel: { id: number; type: string; name: string; user: User[] }
+  channel: Channel
 }
 
 interface User {
@@ -9,4 +9,11 @@ interface User {
   email: string
   name: string
   profileImageUrl: string
+}
+
+interface Channel {
+  id: number
+  type: string
+  name: string
+  user: User[]
 }

--- a/client/src/component/organism/ChannelHeader/index.ts
+++ b/client/src/component/organism/ChannelHeader/index.ts
@@ -1,5 +1,12 @@
 export { default } from './ChannelHeader'
 
 export interface ChannelHeaderProps {
-  channel: object // id, type, name, user[]
+  channel: { id: number; type: string; name: string; user: User[] }
+}
+
+interface User {
+  id: number
+  email: string
+  name: string
+  profileImageUrl: string
 }

--- a/client/src/component/organism/MemberListModal/MemberListModal.stories.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import MemberListModal from '.'
+
+export default {
+  title: 'Organism/MemberListModal',
+  component: MemberListModal,
+}
+
+export const memberListModal = () => {
+  const publicChannel = {
+    id: 1,
+    type: 'PUBLIC',
+    name: 'slack-clone',
+    user: [
+      {
+        id: 1,
+        email: 'dlgkswn885@korea.ac.kr',
+        name: '‍이한주[ 학부재학 / 산업경영공학부 ]',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-N1Pn-Or52MM/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucn7DRZcFBqsGNFc9Z5LUf8hGZRi5g/s96-c/photo.jpg',
+      },
+      {
+        id: 2,
+        email: 'ihanju95@gmail.com',
+        name: '이두주',
+        profileImageUrl:
+          'https://lh3.googleusercontent.com/-VDkRdj9PpUo/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucnTBFod0S-59xYDXy2Y5oG8kAFYnA/s96-c/photo.jpg',
+      },
+      {
+        id: 3,
+        email: 'caribou503@gmail.com',
+        name: 'Seo Young Kim',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+      },
+      {
+        id: 4,
+        email: 'caribou503@gmail.com',
+        name: 'Seo Young Kim',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+      },
+      {
+        id: 4,
+        email: 'caribou503@gmail.com',
+        name: 'Seo Young Kim',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+      },
+      {
+        id: 4,
+        email: 'caribou503@gmail.com',
+        name: 'Seo Young Kim',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+      },
+      {
+        id: 4,
+        email: 'caribou503@gmail.com',
+        name: 'Seo Young Kim',
+        profileImageUrl:
+          'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
+      },
+    ],
+  }
+
+  return <MemberListModal channel={publicChannel} />
+}
+
+memberListModal.story = {
+  name: 'Default',
+}

--- a/client/src/component/organism/MemberListModal/MemberListModal.stories.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.stories.tsx
@@ -29,28 +29,28 @@ export const memberListModal = () => {
       {
         id: 3,
         email: 'caribou503@gmail.com',
-        name: 'Seo Young Kim',
+        name: 'Seo Young Kim)',
         profileImageUrl:
           'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
       },
       {
         id: 4,
         email: 'caribou503@gmail.com',
-        name: 'Seo Young Kim',
+        name: 'Seo Young Kim( + - _ ; \\',
         profileImageUrl:
           'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
       },
       {
         id: 4,
         email: 'caribou503@gmail.com',
-        name: 'Seo Young Kim',
+        name: 'Seo Young Kim#<  ]',
         profileImageUrl:
           'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
       },
       {
         id: 4,
         email: 'caribou503@gmail.com',
-        name: 'Seo Young Kim',
+        name: 'Seo Young Kim @ & " ',
         profileImageUrl:
           'https://lh6.googleusercontent.com/-tOsYv0M4ksY/AAAAAAAAAAI/AAAAAAAAAAA/AMZuuckjb6_Y0uojAO9pKSlhpsKV-ha2Zg/s96-c/photo.jpg',
       },

--- a/client/src/component/organism/MemberListModal/MemberListModal.style.ts
+++ b/client/src/component/organism/MemberListModal/MemberListModal.style.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components'
+import color from '@constant/color'
+
+const Wrapper = styled.div`
+  box-sizing: content-box;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`
+
+const UpperWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 30px 35px 10px 35px;
+`
+
+const MemberListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+`
+
+const MemberWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 10px 35px;
+  &:hover {
+    background-color: ${color.get('whiteHover')};
+  }
+`
+
+const EmptyListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+`
+
+export default {
+  Wrapper,
+  UpperWrapper,
+  MemberListWrapper,
+  MemberWrapper,
+  EmptyListWrapper,
+}

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -22,14 +22,21 @@ const MemberListModal = ({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const input = e.target.value.trim()
     setSearchKeyword(input)
+
+    const escapedInput = input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // 특수문자 검색 처리
     const searchResult =
-      input === '' ? members : members.filter((member) => member.name === input)
+      escapedInput === ''
+        ? members
+        : members.filter((member) => {
+            const regex = new RegExp(escapedInput, 'gi')
+            return member.name.match(regex) || member.email.match(regex)
+          })
     setMemberSearchResult(searchResult)
   }
 
   return (
     <M.Modal
-      overlayStyle={{ opacity: '0.3' }}
+      overlayStyle={{ opacity: '0.4' }}
       modalWrapperStyle={modalWrapperStyle}
       onClose={onClose}
     >

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -3,9 +3,11 @@ import A from '@atom'
 import M from '@molecule'
 import O from '@organism'
 import { TextType } from '@atom/Text'
+import { ButtonType } from '@atom/Button'
 import { InputType } from '@atom/Input'
 import { ModalWrapperType } from '@atom/ModalWrapper'
 import myIcon from '@constant/icon'
+import color from '@constant/color'
 import { MemberListModalProps } from '.'
 import Styled from './MemberListModal.style'
 
@@ -20,10 +22,10 @@ const MemberListModal = ({
   const [memberSearchResult, setMemberSearchResult] = useState(members)
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const input = e.target.value.trim()
+    const input = e.target.value
     setSearchKeyword(input)
 
-    const escapedInput = input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // 특수문자 검색 처리
+    const escapedInput = input.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // 특수문자 검색 처리
     const searchResult =
       escapedInput === ''
         ? members
@@ -32,6 +34,11 @@ const MemberListModal = ({
             return member.name.match(regex) || member.email.match(regex)
           })
     setMemberSearchResult(searchResult)
+  }
+
+  const handleClearSearchButtonClick = (): void => {
+    setSearchKeyword('')
+    setMemberSearchResult(members)
   }
 
   return (
@@ -60,6 +67,7 @@ const MemberListModal = ({
 
           <A.Input
             placeholder="Search members"
+            value={searchKeyword}
             onChange={handleInputChange}
             customStyle={inputStyle}
           />
@@ -74,6 +82,13 @@ const MemberListModal = ({
                   {searchKeyword}
                 </A.Text>
               </div>
+              <M.ButtonDiv
+                buttonStyle={clearSearchButtonStyle}
+                textStyle={clearSearchButtonTextStyle}
+                onClick={handleClearSearchButtonClick}
+              >
+                Clear search
+              </M.ButtonDiv>
             </Styled.EmptyListWrapper>
           ) : (
             memberSearchResult.map((member) => (
@@ -126,6 +141,19 @@ const searchKeywordTextStyle: TextType.StyleAttributes = {
 const memberNameTextStyle: TextType.StyleAttributes = {
   fontWeight: '600',
   margin: '0 0 0 10px',
+}
+
+const clearSearchButtonStyle: ButtonType.StyleAttributes = {
+  margin: '10px',
+  padding: '10px',
+  border: '1px solid grey',
+  backgroundColor: 'white',
+  hoverBackgroundColor: color.get('whiteHover'),
+}
+
+const clearSearchButtonTextStyle: TextType.StyleAttributes = {
+  fontSize: '0.9rem',
+  fontWeight: '600',
 }
 
 export default MemberListModal

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -39,6 +39,7 @@ const MemberListModal = ({
       overlayStyle={{ opacity: '0.4' }}
       modalWrapperStyle={modalWrapperStyle}
       onClose={onClose}
+      fixed
     >
       <Styled.Wrapper>
         <Styled.UpperWrapper>

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react'
+import A from '@atom'
+import M from '@molecule'
+import O from '@organism'
+import { TextType } from '@atom/Text'
+import { InputType } from '@atom/Input'
+import { ModalWrapperType } from '@atom/ModalWrapper'
+import myIcon from '@constant/icon'
+import { MemberListModalProps } from '.'
+import Styled from './MemberListModal.style'
+
+const MemberListModal = ({
+  channel,
+  onAddPeopleClick,
+  onClose,
+}: MemberListModalProps) => {
+  const { id, type, name, user: members } = channel
+
+  const [searchKeyword, setSearchKeyword] = useState('')
+  const [memberSearchResult, setMemberSearchResult] = useState(members)
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const input = e.target.value.trim()
+    setSearchKeyword(input)
+    const searchResult =
+      input === '' ? members : members.filter((member) => member.name === input)
+    setMemberSearchResult(searchResult)
+  }
+
+  return (
+    <M.Modal
+      overlayStyle={{ opacity: '0.3' }}
+      modalWrapperStyle={modalWrapperStyle}
+      onClose={onClose}
+    >
+      <Styled.Wrapper>
+        <Styled.UpperWrapper>
+          <A.Text customStyle={modalTitleTextStyle}>
+            <>
+              {`${members.length} members in`}
+              <A.Icon
+                icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock}
+                customStyle={{ margin: '0 3px 0 6px' }}
+              />
+              {name}
+            </>
+          </A.Text>
+
+          <A.Text customStyle={{ color: 'blue' }} onClick={onAddPeopleClick}>
+            Add people
+          </A.Text>
+
+          <A.Input
+            placeholder="Search members"
+            onChange={handleInputChange}
+            customStyle={inputStyle}
+          />
+        </Styled.UpperWrapper>
+
+        <Styled.MemberListWrapper>
+          {memberSearchResult.length === 0 ? (
+            <Styled.EmptyListWrapper>
+              <div>
+                No matches found for
+                <A.Text customStyle={searchKeywordTextStyle}>
+                  {searchKeyword}
+                </A.Text>
+              </div>
+            </Styled.EmptyListWrapper>
+          ) : (
+            memberSearchResult.map((member) => (
+              <Styled.MemberWrapper>
+                <O.Avatar user={member} size="BIG" clickable />
+                <A.Text customStyle={memberNameTextStyle}>{member.name}</A.Text>
+              </Styled.MemberWrapper>
+            ))
+          )}
+        </Styled.MemberListWrapper>
+      </Styled.Wrapper>
+    </M.Modal>
+  )
+}
+
+const modalWrapperStyle: ModalWrapperType.StyleAttributes = {
+  width: 'auto',
+  padding: '0',
+  backgroundColor: 'white',
+  border: '1px solid transparent',
+  borderRadius: '8px',
+  boxShadow: 'none',
+  overflow: 'visible',
+  position: 'fixed',
+  left: '30%',
+  top: '15%',
+  right: '30%',
+  bottom: '15%',
+}
+
+const modalTitleTextStyle: TextType.StyleAttributes = {
+  fontWeight: '800',
+  fontSize: '22px',
+  margin: '0 0 1rem 0',
+}
+
+const inputStyle: InputType.StyleAttributes = {
+  border: '1px solid grey',
+  borderRadius: '5px',
+  padding: '0 10px',
+  margin: '12px 0',
+  fontSize: '1rem',
+}
+
+const searchKeywordTextStyle: TextType.StyleAttributes = {
+  fontWeight: 'bold',
+  margin: '0 0 0 5px',
+}
+
+const memberNameTextStyle: TextType.StyleAttributes = {
+  fontWeight: '600',
+  margin: '0 0 0 10px',
+}
+
+export default MemberListModal

--- a/client/src/component/organism/MemberListModal/index.ts
+++ b/client/src/component/organism/MemberListModal/index.ts
@@ -1,0 +1,21 @@
+export { default } from './MemberListModal'
+
+export interface MemberListModalProps {
+  channel: Channel
+  onAddPeopleClick?: () => void
+  onClose?: () => void
+}
+
+interface User {
+  id: number
+  email: string
+  name: string
+  profileImageUrl: string
+}
+
+interface Channel {
+  id: number
+  type: string
+  name: string
+  user: User[]
+}

--- a/client/src/component/organism/index.ts
+++ b/client/src/component/organism/index.ts
@@ -7,6 +7,7 @@ import ReactionPicker from './ReactionPicker'
 import UserProfileModal from './UserProfileModal'
 import Avatar from './Avatar'
 import ChannelHeader from './ChannelHeader'
+import MemberListModal from './MemberListModal'
 
 export default {
   Header,
@@ -18,4 +19,5 @@ export default {
   UserProfileModal,
   Avatar,
   ChannelHeader,
+  MemberListModal,
 }


### PR DESCRIPTION
## Linked Issue
close #55
close #54

## 공유할 사항 
- `ChannelHeader`의 Member count과 profile prev를 보여주는 버튼 구현 - 클릭 시 `MemberListModal` 렌더링
- `MemberListModal` 컴포넌트 구현
  - 프론트에서 가지고 있는 데이터에서 검색
<img width="1037" alt="스크린샷 2020-11-29 오전 5 10 25" src="https://user-images.githubusercontent.com/57661699/100525130-63768580-3201-11eb-9f00-5cc964199ab7.png">

<img width="426" alt="스크린샷 2020-11-29 오전 5 10 39" src="https://user-images.githubusercontent.com/57661699/100525133-66717600-3201-11eb-83cb-9349d52a7923.png">
<img width="431" alt="스크린샷 2020-11-29 오전 5 10 49" src="https://user-images.githubusercontent.com/57661699/100525134-66717600-3201-11eb-9a99-dabb4eb5a909.png">

- Clear search 버튼 추가
<img width="372" alt="스크린샷 2020-11-30 오후 1 08 37" src="https://user-images.githubusercontent.com/57661699/100567995-357e6780-330d-11eb-8b77-12e2123ca8d3.png">


## Note
- Image, Input 컴포넌트에 필요한 props를 추가했습니다.

## 해결해야 할 사항
- MemberList 모달 내부의 컴포넌트 안에 종속되는 또다른 모달인 UserProfile 컴포넌트가 overflow 속성의 문제로 잘려보입니다...
<img width="452" alt="스크린샷 2020-11-29 오전 5 15 57" src="https://user-images.githubusercontent.com/57661699/100525200-0d561200-3202-11eb-9bd8-e799770707c3.png">
