### PR TITLE
Refactor/be/swagger

### DIFF
--- a/server/src/controller/user/user.controller.ts
+++ b/server/src/controller/user/user.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import jwt from '../../util/jwt'
+import jwt from '@util/jwt'
 
 const frontURL =
   process.env.NODE_ENV === 'development'

--- a/server/src/controller/workspace/workspace.controller.ts
+++ b/server/src/controller/workspace/workspace.controller.ts
@@ -6,11 +6,12 @@ const createWorkspace = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const newWorkspaceData = req.body
   try {
-    const { code, json } = await workspaceService.createWorkspace(
-      newWorkspaceData,
-    )
+    const { code, json } = await workspaceService.createWorkspace({
+      userId: req.user.id,
+      name: req.body.name,
+      imageUrl: req.body.imageUrl,
+    })
     return res.status(code).json(json)
   } catch (error) {
     return next(error)

--- a/server/src/service/workspace.service.ts
+++ b/server/src/service/workspace.service.ts
@@ -63,7 +63,7 @@ const readWorkspaceByUser = async ({ userId }: WorkspaceType) => {
         },
       ],
     })
-    console.log(workspaces)
+
     return {
       code: statusCode.OK,
       json: {

--- a/server/src/service/workspace.service.ts
+++ b/server/src/service/workspace.service.ts
@@ -9,6 +9,12 @@ interface WorkspaceType {
   workspaceId?: number
 }
 
+interface WorkspaceInstance extends WorkspaceModel {
+  // eslint-disable-next-line no-unused-vars
+  addUser: (id: number) => Promise<void>
+  user: UserModel[]
+}
+
 const isValidNewWorkspaceData = ({ name, imageUrl }: WorkspaceType) => {
   if (!name || !imageUrl || name === '' || imageUrl === '') return false
   if (!(typeof name === 'string') || !(typeof imageUrl === 'string')) {
@@ -17,7 +23,7 @@ const isValidNewWorkspaceData = ({ name, imageUrl }: WorkspaceType) => {
   return true
 }
 
-const createWorkspace = async ({ name, imageUrl }: WorkspaceType) => {
+const createWorkspace = async ({ userId, name, imageUrl }: WorkspaceType) => {
   if (!isValidNewWorkspaceData({ name, imageUrl })) {
     return {
       code: statusCode.BAD_REQUEST,
@@ -26,7 +32,11 @@ const createWorkspace = async ({ name, imageUrl }: WorkspaceType) => {
   }
 
   try {
-    await WorkspaceModel.create({ name, imageUrl })
+    const workspace = (await WorkspaceModel.create({
+      name,
+      imageUrl,
+    })) as WorkspaceInstance
+    await workspace.addUser(userId)
     return {
       code: statusCode.CREATED,
       json: {
@@ -53,6 +63,7 @@ const readWorkspaceByUser = async ({ userId }: WorkspaceType) => {
         },
       ],
     })
+    console.log(workspaces)
     return {
       code: statusCode.OK,
       json: {
@@ -66,12 +77,6 @@ const readWorkspaceByUser = async ({ userId }: WorkspaceType) => {
       json: { success: false, message: resMessage.DB_ERROR },
     }
   }
-}
-
-interface WorkspaceInstance extends WorkspaceModel {
-  // eslint-disable-next-line no-unused-vars
-  addUser: (id: number) => Promise<void>
-  user: UserModel[]
 }
 
 const joinWorkspace = async ({ userId, workspaceId }: WorkspaceType) => {

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -5,8 +5,19 @@ info:
   description: Slack Web TEAM A의 API 문서입니다
   license:
     name: MIT
-host: http://localhost:3000
-basePath: /
+servers:
+  - description: dev server
+    url: http://127.0.0.1:3000
+  - description: hyex production server
+    url: http://101.101.219.79:3000
+tags:
+  - user
+  - workspace
+  - channel
+  - thread
+  - message
+  - file
+  - reaction
 paths:
   $ref: './paths/_index.yaml'
 components:
@@ -29,7 +40,7 @@ components:
           type: integer
         email:
           type: string
-        name: 
+        name:
           type: string
         googleId:
           type: string
@@ -51,7 +62,7 @@ components:
       properties:
         id:
           type: integer
-        name: 
+        name:
           type: string
         imageUrl:
           type: string
@@ -75,17 +86,17 @@ components:
           type: datetime
         updatedAt:
           type: datetime
-    Channel: 
+    Channel:
       type: object
-      required: 
+      required:
         - name
         - type
         - createdAt
         - updatedAt
       properties:
-        name: 
+        name:
           type: string
-        type: 
+        type:
           type: string
         createdAt:
           type: datetime
@@ -93,11 +104,11 @@ components:
           type: datetime
         deletedAt:
           type: datetime
-    Section: 
+    Section:
       type: object
-      required: 
+      required:
         - id
-        - name        
+        - name
         - createdAt
         - updatedAt
       properties:
@@ -190,7 +201,7 @@ components:
       properties:
         id:
           type: integer
-        content: 
+        content:
           type: string
         messageId:
           type: integer
@@ -215,7 +226,7 @@ components:
           type: integer
         url:
           type: string
-        type: 
+        type:
           type: string
         messageId:
           type: string

--- a/server/src/swagger/paths/channel-info.yaml
+++ b/server/src/swagger/paths/channel-info.yaml
@@ -1,5 +1,7 @@
 get:
   summary: get channel info api (thread, message, reaction, file)
+  tags:
+    - channel
   security:
     - BearerAuth: []
   parameters:
@@ -7,7 +9,6 @@ get:
       name: channelId
       description: channel id
       type: integer
-
   responses:
     '200':
       description: channel의 threads, messages, users 등

--- a/server/src/swagger/paths/channel-join.yaml
+++ b/server/src/swagger/paths/channel-join.yaml
@@ -1,5 +1,7 @@
 post:
   summary: channel join api
+  tags:
+    - channel
   security:
     - BearerAuth: []
   parameters:

--- a/server/src/swagger/paths/channel.yaml
+++ b/server/src/swagger/paths/channel.yaml
@@ -1,5 +1,7 @@
 get:
   summary: 로그인한 User가 속한 Channel들을 가지고온다.
+  tags:
+    - channel
   security:
     - BearerAuth: []
   responses:
@@ -23,6 +25,8 @@ get:
 
 post:
   summary: channel create api
+  tags:
+    - channel
   security:
     - BearerAuth: []
   requestBody:

--- a/server/src/swagger/paths/file.yaml
+++ b/server/src/swagger/paths/file.yaml
@@ -1,5 +1,7 @@
 post:
   summary: file create api
+  tags:
+    - file
   security:
     - BearerAuth: []
   requestBody:

--- a/server/src/swagger/paths/message.yaml
+++ b/server/src/swagger/paths/message.yaml
@@ -1,5 +1,7 @@
 post:
   summary: message create api
+  tags:
+    - message
   security:
     - BearerAuth: []
   requestBody:

--- a/server/src/swagger/paths/reaction.yaml
+++ b/server/src/swagger/paths/reaction.yaml
@@ -1,5 +1,7 @@
 post:
   summary: create or remove reaction
+  tags:
+    - reaction
   security:
     - BearerAuth: []
   requestBody:

--- a/server/src/swagger/paths/thread.yaml
+++ b/server/src/swagger/paths/thread.yaml
@@ -1,5 +1,7 @@
 post:
   summary: thread create api
+  tags:
+    - thread
   security:
     - BearerAuth: []
   requestBody:

--- a/server/src/swagger/paths/user.yaml
+++ b/server/src/swagger/paths/user.yaml
@@ -1,5 +1,7 @@
 get:
   summary: 유저의 token 정보의 유효성을 검사하며, jwt에 따른 유저의 정보를 요청한다.
+  tags:
+    - user
   security:
     - BearerAuth: []
   responses:

--- a/server/src/swagger/paths/workspace-join.yaml
+++ b/server/src/swagger/paths/workspace-join.yaml
@@ -1,5 +1,7 @@
 post:
   summary: workspace join api
+  tags:
+    - workspace
   security:
     - BearerAuth: []
   requestBody:
@@ -11,7 +13,6 @@ post:
             workspaceId:
               type: number
               description: workspace id
-
   responses:
     '201':
       description: workspace join 성공
@@ -23,7 +24,8 @@ post:
               success:
                 type: boolean
     '400':
-      description: BadRequest, 이미 로그인한 유저는 해당 workspace에 포함되어 있음
+      description: 이미 로그인한 유저는 해당 workspace에 포함되어 있음
+      $ref: '../openapi.yaml#/components/responses/BadRequest'
     '500':
       $ref: '../openapi.yaml#/components/responses/InternalServerError'
     '600':

--- a/server/src/swagger/paths/workspace-userlist.yaml
+++ b/server/src/swagger/paths/workspace-userlist.yaml
@@ -1,5 +1,7 @@
 get:
   summary: get workspace user list api
+  tags:
+    - workspace
   security:
     - BearerAuth: []
   parameters:
@@ -7,7 +9,6 @@ get:
       name: workspaceId
       description: workspace id
       type: integer
-
   responses:
     '200':
       description: workspace user list 조회 성공
@@ -18,8 +19,17 @@ get:
             properties:
               success:
                 type: boolean
-              data: 
+              data:
                 type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    email:
+                      type: string
+                    profileImageUrl:
+                      type: string
     '500':
       $ref: '../openapi.yaml#/components/responses/InternalServerError'
     '600':

--- a/server/src/swagger/paths/workspace.yaml
+++ b/server/src/swagger/paths/workspace.yaml
@@ -1,27 +1,7 @@
-get:
-  summary: 로그인한 User가 속한 workspace를 가지고온다.
-  security:
-    - BearerAuth: []
-  responses:
-    '201':
-      description: OK
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              success:
-                type: boolean
-                data: array
-    '400':
-      description: BadRequest
-    '500':
-      $ref: '../openapi.yaml#/components/responses/InternalServerError'
-    '600':
-      $ref: '../openapi.yaml#/components/responses/DBError'
-
 post:
-  summary: workspace create api
+  summary: workspace 생성
+  tags:
+    - workspace
   security:
     - BearerAuth: []
   requestBody:
@@ -44,6 +24,33 @@ post:
             properties:
               success:
                 type: boolean
+    '400':
+      $ref: '../openapi.yaml#/components/responses/BadRequest'
+    '500':
+      $ref: '../openapi.yaml#/components/responses/InternalServerError'
+    '600':
+      $ref: '../openapi.yaml#/components/responses/DBError'
+get:
+  summary: 로그인한 User가 속한 workspace를 가지고온다.
+  tags:
+    - workspace
+  security:
+    - BearerAuth: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              data:
+                type: array
+                items:
+                  $ref: '../openapi.yaml#/components/schemas/Workspace'
+
     '400':
       description: BadRequest
     '500':


### PR DESCRIPTION
## 공유할 사항  
- swagger docs를 정리했습니다.
![image](https://user-images.githubusercontent.com/48546343/100546958-7fccfd80-32a7-11eb-813b-3cf721448312.png)
- workspace docs와 코드를 비교하며 변경 사항과 논의할 사항을 생각했고 내일 데일리 스크럼 이후에 공유하겠습니다.

## 논의할 사항 
- workspace API 정리
  - 변경사항 1) workspace 생성 시 해당 유저가 바로 가입되도록(UserWorkspace 컬럼 추가) 변경
  - 논의 사항 1) 변경사항 1번에서 transaction이 필요할 것 같은데 맞나요? (그렇다면 어떻게 ..? `addUser` 타입 재지정해야할 듯)
  - 논의 사항 2) workspace 생성 시 imageURL이 안들어오면 verify 함수에서 걸리던데, imageURL이 필수인가요?
  - 질문 1) workspace/:workspaceId/userlist API에서 왜 `userlist`만 카멜케이스가 적용되지 않았는지
