### PR TITLE
Feature/be/thread message update delete (#127, #128, #129, #130, #136)

### DIFF
--- a/server/src/controller/message/index.ts
+++ b/server/src/controller/message/index.ts
@@ -5,5 +5,6 @@ const router = Router()
 
 router.post('/', messageController.createMessage)
 router.patch('/:id', messageController.updateMessage)
+router.delete('/:id', messageController.deleteMessage)
 
 export default router

--- a/server/src/controller/message/index.ts
+++ b/server/src/controller/message/index.ts
@@ -4,5 +4,6 @@ import messageController from './message.controller'
 const router = Router()
 
 router.post('/', messageController.createMessage)
+router.patch('/:id', messageController.updateMessage)
 
 export default router

--- a/server/src/controller/message/message.controller.ts
+++ b/server/src/controller/message/message.controller.ts
@@ -37,4 +37,20 @@ const updateMessage = async (
   }
 }
 
-export default { createMessage, updateMessage }
+const deleteMessage = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { code, json } = await messageService.deleteMessage({
+      id: +req.params.id,
+      userId: +req.user.id,
+    })
+    return res.status(code).json(json)
+  } catch (error) {
+    return next(error)
+  }
+}
+
+export default { createMessage, updateMessage, deleteMessage }

--- a/server/src/controller/message/message.controller.ts
+++ b/server/src/controller/message/message.controller.ts
@@ -46,6 +46,7 @@ const deleteMessage = async (
     const { code, json } = await messageService.deleteMessage({
       id: +req.params.id,
       userId: +req.user.id,
+      threadId: +req.body.threadId,
     })
     return res.status(code).json(json)
   } catch (error) {

--- a/server/src/controller/message/message.controller.ts
+++ b/server/src/controller/message/message.controller.ts
@@ -19,4 +19,22 @@ const createMessage = async (
   }
 }
 
-export default { createMessage }
+const updateMessage = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { code, json } = await messageService.updateMessage({
+      id: +req.params.id,
+      userId: +req.user.id,
+      content: req.body.content,
+      fileInfoList: req.body.fileInfoList,
+    })
+    return res.status(code).json(json)
+  } catch (error) {
+    return next(error)
+  }
+}
+
+export default { createMessage, updateMessage }

--- a/server/src/controller/thread/index.ts
+++ b/server/src/controller/thread/index.ts
@@ -4,5 +4,6 @@ import threadController from './thread.controller'
 const router = Router()
 
 router.post('/', threadController.createThread)
+router.delete('/:id', threadController.deleteThread)
 
 export default router

--- a/server/src/controller/thread/index.ts
+++ b/server/src/controller/thread/index.ts
@@ -4,6 +4,7 @@ import threadController from './thread.controller'
 const router = Router()
 
 router.post('/', threadController.createThread)
+router.get('/', threadController.readThreadsByChannel)
 router.delete('/:id', threadController.deleteThread)
 
 export default router

--- a/server/src/controller/thread/thread.controller.ts
+++ b/server/src/controller/thread/thread.controller.ts
@@ -19,6 +19,23 @@ const createThread = async (
   }
 }
 
+const readThreadsByChannel = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  console.log(req.query.channelId)
+  try {
+    const { code, json } = await threadService.readThreadsByChannel({
+      userId: +req.user.id,
+      channelId: +req.query.channelId,
+    })
+    return res.status(code).json(json)
+  } catch (error) {
+    return next(error)
+  }
+}
+
 const deleteThread = async (
   req: Request,
   res: Response,
@@ -35,4 +52,4 @@ const deleteThread = async (
   }
 }
 
-export default { createThread, deleteThread }
+export default { createThread, readThreadsByChannel, deleteThread }

--- a/server/src/controller/thread/thread.controller.ts
+++ b/server/src/controller/thread/thread.controller.ts
@@ -19,4 +19,20 @@ const createThread = async (
   }
 }
 
-export default { createThread }
+const deleteThread = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { code, json } = await threadService.deleteThread({
+      id: +req.params.id,
+      userId: req.user.id,
+    })
+    return res.status(code).json(json)
+  } catch (error) {
+    return next(error)
+  }
+}
+
+export default { createThread, deleteThread }

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -2,7 +2,6 @@ import messageModel from '@model/message.model'
 import FileModel from '@model/file.model'
 import { sequelize } from '@model/sequelize'
 import { statusCode, resMessage } from '@util/constant'
-import validtor from '@util/validator'
 import validator from '@util/validator'
 
 interface FileInfo extends Object {

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -122,4 +122,32 @@ const updateMessage = async ({
     }
   }
 }
-export default { createMessage, updateMessage }
+
+const deleteMessage = async ({ id, userId }: MessageType) => {
+  if (!isValidNumber(id) || !isValidNumber(userId))
+    return {
+      code: statusCode.BAD_REQUEST,
+      json: { success: false, message: resMessage.OUT_OF_VALUE },
+    }
+
+  const t = await sequelize.transaction()
+  try {
+    await messageModel.destroy({ where: { id, userId }, transaction: t })
+    await FileModel.destroy({ where: { messageId: id } })
+
+    await t.commit()
+    return {
+      code: statusCode.OK,
+      json: { success: true },
+    }
+  } catch (error) {
+    await t.rollback()
+    console.log(error)
+    return {
+      code: statusCode.DB_ERROR,
+      json: { success: false, message: resMessage.DB_ERROR },
+    }
+  }
+}
+
+export default { createMessage, updateMessage, deleteMessage }

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -2,6 +2,8 @@ import messageModel from '@model/message.model'
 import FileModel from '@model/file.model'
 import { sequelize } from '@model/sequelize'
 import { statusCode, resMessage } from '@util/constant'
+import validtor from '@util/validator'
+import validator from '@util/validator'
 
 interface FileInfo extends Object {
   filePath: string
@@ -65,18 +67,12 @@ const createMessage = async ({
   }
 }
 
-const isValidNumber = (num: number) => {
-  if (!num || num < 1 || Number.isNaN(num)) return false
-  return true
-}
-
-const isValidString = (str: string) => {
-  if (!str || str === '') return false
-  return true
-}
-
 const isValidMessageData = ({ id, userId, content }: MessageType) => {
-  return isValidNumber(id) && isValidNumber(userId) && isValidString(content)
+  return (
+    validator.isNumber(id) &&
+    validator.isNumber(userId) &&
+    validator.isString(content)
+  )
 }
 
 const updateMessage = async ({
@@ -124,7 +120,7 @@ const updateMessage = async ({
 }
 
 const deleteMessage = async ({ id, userId }: MessageType) => {
-  if (!isValidNumber(id) || !isValidNumber(userId))
+  if (!validator.isNumber(id) || !validator.isNumber(userId))
     return {
       code: statusCode.BAD_REQUEST,
       json: { success: false, message: resMessage.OUT_OF_VALUE },

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -41,12 +41,14 @@ const createMessage = async ({
       { transaction: t },
     )
 
-    await FileModel.bulkCreate(
-      fileInfoList.map(({ filePath, type }) => {
-        return { url: filePath, type, messageId: newMessage.id }
-      }),
-      { transaction: t },
-    )
+    if (fileInfoList) {
+      await FileModel.bulkCreate(
+        fileInfoList.map(({ filePath, type }) => {
+          return { url: filePath, type, messageId: newMessage.id }
+        }),
+        { transaction: t },
+      )
+    }
 
     await t.commit()
     return {

--- a/server/src/service/message.service.ts
+++ b/server/src/service/message.service.ts
@@ -9,9 +9,10 @@ interface FileInfo extends Object {
 }
 
 interface MessageType {
-  userId: number
-  threadId: number
-  content: string
+  id?: number
+  userId?: number
+  threadId?: number
+  content?: string
   fileInfoList?: FileInfo[]
 }
 
@@ -62,4 +63,61 @@ const createMessage = async ({
   }
 }
 
-export default { createMessage }
+const isValidNumber = (num: number) => {
+  if (!num || num < 1 || Number.isNaN(num)) return false
+  return true
+}
+
+const isValidString = (str: string) => {
+  if (!str || str === '') return false
+  return true
+}
+
+const isValidMessageData = ({ id, userId, content }: MessageType) => {
+  return isValidNumber(id) && isValidNumber(userId) && isValidString(content)
+}
+
+const updateMessage = async ({
+  id,
+  userId,
+  content,
+  fileInfoList,
+}: MessageType) => {
+  if (!isValidMessageData({ id, userId, content }))
+    return {
+      code: statusCode.BAD_REQUEST,
+      json: { success: false, message: resMessage.OUT_OF_VALUE },
+    }
+
+  const t = await sequelize.transaction()
+  try {
+    await messageModel.update(
+      { content },
+      { where: { id, userId }, transaction: t },
+    )
+
+    if (fileInfoList) {
+      await FileModel.destroy({ where: { messageId: id } })
+      await FileModel.bulkCreate(
+        fileInfoList.map(({ filePath, type }) => {
+          return { url: filePath, type, messageId: id }
+        }),
+        { transaction: t },
+      )
+    }
+
+    await t.commit()
+    return {
+      code: statusCode.OK,
+      json: { success: true },
+    }
+  } catch (error) {
+    await t.rollback()
+    console.log(error)
+    return {
+      code: statusCode.DB_ERROR,
+      json: { success: false, message: resMessage.DB_ERROR },
+    }
+  }
+}
+export default { createMessage, updateMessage }

--- a/server/src/service/thread.service.ts
+++ b/server/src/service/thread.service.ts
@@ -42,12 +42,14 @@ const createThread = async ({
       { transaction: t },
     )
 
-    await FileModel.bulkCreate(
-      fileInfoList.map(({ filePath, type }) => {
-        return { url: filePath, type, messageId: newMessage.id }
-      }),
-      { transaction: t },
-    )
+    if (fileInfoList) {
+      await FileModel.bulkCreate(
+        fileInfoList.map(({ filePath, type }) => {
+          return { url: filePath, type, messageId: newMessage.id }
+        }),
+        { transaction: t },
+      )
+    }
 
     await t.commit()
     return {

--- a/server/src/service/thread.service.ts
+++ b/server/src/service/thread.service.ts
@@ -68,6 +68,33 @@ const createThread = async ({
   }
 }
 
+interface readThreadType {
+  userId: number
+  channelId: number
+}
+
+const readThreadsByChannel = async ({ userId, channelId }: readThreadType) => {
+  if (!validator.isNumber(userId) || !validator.isNumber(channelId))
+    return {
+      code: statusCode.BAD_REQUEST,
+      json: { success: false, message: resMessage.OUT_OF_VALUE },
+    }
+
+  try {
+    const threads = await ThreadModel.findAll({ where: { channelId } })
+    return {
+      code: statusCode.OK,
+      json: { success: true, data: threads },
+    }
+  } catch (error) {
+    console.log(error)
+    return {
+      code: statusCode.DB_ERROR,
+      json: { success: false, message: resMessage.DB_ERROR },
+    }
+  }
+}
+
 interface deleteThreadType {
   id: number
   userId: number
@@ -100,4 +127,4 @@ const deleteThread = async ({ id, userId }: deleteThreadType) => {
   }
 }
 
-export default { createThread, deleteThread }
+export default { createThread, readThreadsByChannel, deleteThread }

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -228,6 +228,10 @@ components:
           type: string
         type:
           type: string
+          enum:
+            - FILE
+            - VIDEO
+            - IMAGE
         messageId:
           type: string
         createdAt:

--- a/server/src/swagger/paths/_index.yaml
+++ b/server/src/swagger/paths/_index.yaml
@@ -16,6 +16,8 @@
   $ref: './thread.yaml'
 /api/message:
   $ref: './message.yaml'
+/api/message/{id}:
+  $ref: './message-id.yaml'
 /api/reaction:
   $ref: './reaction.yaml'
 /api/file:

--- a/server/src/swagger/paths/_index.yaml
+++ b/server/src/swagger/paths/_index.yaml
@@ -14,6 +14,8 @@
   $ref: './channel-join.yaml'
 /api/thread:
   $ref: './thread.yaml'
+/api/thread/{id}:
+  $ref: './thread-id.yaml'
 /api/message:
   $ref: './message.yaml'
 /api/message/{id}:

--- a/server/src/swagger/paths/message-id.yaml
+++ b/server/src/swagger/paths/message-id.yaml
@@ -41,3 +41,29 @@ patch:
       $ref: '../openapi.yaml#/components/responses/InternalServerError'
     '600':
       $ref: '../openapi.yaml#/components/responses/DBError'
+delete:
+  summary: delete message
+  tags:
+    - message
+  security:
+    - BearerAuth: []
+  parameters:
+    - in: path
+      name: id
+      description: message id
+      type: integer
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+    '400':
+      $ref: '../openapi.yaml#/components/responses/BadRequest'
+    '500':
+      $ref: '../openapi.yaml#/components/responses/InternalServerError'
+    '600':
+      $ref: '../openapi.yaml#/components/responses/DBError'

--- a/server/src/swagger/paths/message-id.yaml
+++ b/server/src/swagger/paths/message-id.yaml
@@ -1,0 +1,43 @@
+patch:
+  summary: update message
+  tags:
+    - message
+  security:
+    - BearerAuth: []
+  parameters:
+    - in: path
+      name: id
+      description: message id
+      type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            content:
+              type: string
+            fileInfoList:
+              type: array
+              items:
+                type: object
+                properties:
+                  filePath:
+                    type: string
+                  type:
+                    type: string
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+    '400':
+      $ref: '../openapi.yaml#/components/responses/BadRequest'
+    '500':
+      $ref: '../openapi.yaml#/components/responses/InternalServerError'
+    '600':
+      $ref: '../openapi.yaml#/components/responses/DBError'

--- a/server/src/swagger/paths/message-id.yaml
+++ b/server/src/swagger/paths/message-id.yaml
@@ -56,6 +56,14 @@ delete:
       name: id
       description: message id
       type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            threadId:
+              type: integer
   responses:
     '200':
       content:

--- a/server/src/swagger/paths/message-id.yaml
+++ b/server/src/swagger/paths/message-id.yaml
@@ -26,6 +26,10 @@ patch:
                     type: string
                   type:
                     type: string
+                    enum:
+                      - FILE
+                      - VIDEO
+                      - IMAGE
   responses:
     '200':
       content:

--- a/server/src/swagger/paths/thread-id.yaml
+++ b/server/src/swagger/paths/thread-id.yaml
@@ -1,0 +1,26 @@
+delete:
+  summary: delete thread
+  tags:
+    - thread
+  security:
+    - BearerAuth: []
+  parameters:
+    - in: path
+      name: id
+      description: thread id
+      type: integer
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+    '400':
+      $ref: '../openapi.yaml#/components/responses/BadRequest'
+    '500':
+      $ref: '../openapi.yaml#/components/responses/InternalServerError'
+    '600':
+      $ref: '../openapi.yaml#/components/responses/DBError'

--- a/server/src/swagger/paths/thread.yaml
+++ b/server/src/swagger/paths/thread.yaml
@@ -14,6 +14,19 @@ post:
               type: string
             channelId:
               type: number
+            fileInfoList:
+              type: array
+              items:
+                type: object
+                properties:
+                  filePath:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - FILE
+                      - VIDEO
+                      - IMAGE
 
   responses:
     '201':

--- a/server/src/swagger/paths/thread.yaml
+++ b/server/src/swagger/paths/thread.yaml
@@ -42,3 +42,34 @@ post:
       $ref: '../openapi.yaml#/components/responses/InternalServerError'
     '600':
       $ref: '../openapi.yaml#/components/responses/DBError'
+get:
+  summary: thread create api
+  tags:
+    - thread
+  security:
+    - BearerAuth: []
+  parameters:
+    - in: query
+      name: channelId
+      description: channel id
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              data:
+                type: array
+                items:
+                  $ref: '../openapi.yaml#/components/schemas/Thread'
+
+    '500':
+      $ref: '../openapi.yaml#/components/responses/InternalServerError'
+    '600':
+      $ref: '../openapi.yaml#/components/responses/DBError'

--- a/server/src/util/validator.ts
+++ b/server/src/util/validator.ts
@@ -1,0 +1,11 @@
+export default {
+  isNumber: (num: number) => {
+    if (!num || num < 1 || Number.isNaN(num)) return false
+    return true
+  },
+
+  isString: (str: string) => {
+    if (!str || str === '') return false
+    return true
+  },
+}


### PR DESCRIPTION
## Linked Issue
close #127 
close #128 
close #129  
close #130  
related #136 

## 공유할 사항 
- #127 thread update api는 필요없어 구현하지 않았습니다.
- #128 thread delete api를 구현하였습니다. thread 삭제 시 메시지도 같이 삭제되도록 구현하였으나 사용할 일은 없어보입니다.
- #129 message update api를 구현하였습니다. message의 모든 fileInfoList를 바디에 넘겨주면 기존에 있던 file rows 를 모두 삭제하고 다시 생성하는 로직을 구현했습니다 (더 좋은 방법이 있을까요?)
- #130 message delete api를 구현하였습니다. 만약 thread의 하나 남은 message라면 thread까지 삭제되도록 하여 body로 `threadId`를 받습니다.
- #136 소켓 연결을 위해 get thread API가 필요해서 임시로 만들었습니다. 
