### PR TITLE
Sidebar에 channel List 추가, channel 클릭 시 해당 channel page로 이동 (#38)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -53,6 +53,9 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: border-box;
     font-size: 62.5%;
   }
+  a {
+    text-decoration: none;
+  }
 `
 
 export default App

--- a/client/src/component/atom/Icon/index.ts
+++ b/client/src/component/atom/Icon/index.ts
@@ -1,4 +1,5 @@
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { MouseEvent } from 'react'
 
 export { default } from './Icon'
 
@@ -28,6 +29,6 @@ export namespace IconType {
   export interface Props {
     icon: IconDefinition
     customStyle?: StyleAttributes
-    onClick?: () => void
+    onClick?: (event: MouseEvent<HTMLSpanElement>) => void
   }
 }

--- a/client/src/component/molecule/Section/Section.tsx
+++ b/client/src/component/molecule/Section/Section.tsx
@@ -18,7 +18,7 @@ const Section = ({ title, type }: SectionProps) => {
     setSectionHover(!sectionHover)
   }
 
-  const handleMoreOptionsClick = (event: MouseEvent) => {
+  const handleMoreOptionsClick = (event: MouseEvent<HTMLSpanElement>) => {
     moreOverWrapperStyle.left = String(`${event.pageX + 5}px`)
     moreOverWrapperStyle.top = String(`${event.pageY + 5}px`)
     setMoreOptions(!moreOptions)

--- a/client/src/component/molecule/Section/Section.tsx
+++ b/client/src/component/molecule/Section/Section.tsx
@@ -1,11 +1,13 @@
 import React, { useState, MouseEvent } from 'react'
+import { Link } from 'react-router-dom'
 import A from '@atom'
 import M from '@molecule'
+import O from '@organism'
 import myIcon from '@constant/icon'
 import Styled from './Section.style'
 import { SectionProps } from '.'
 
-const Section = ({ title, type }: SectionProps) => {
+const Section = ({ title, type, channelList, workspaceId }: SectionProps) => {
   const [toggle, setToggle] = useState<boolean>(false)
   const [sectionHover, setSectionHover] = useState<boolean>(false)
   const [moreOptions, setMoreOptions] = useState<boolean>(false)
@@ -27,7 +29,7 @@ const Section = ({ title, type }: SectionProps) => {
   // TODO: 채널 클릭 시 액션
   const handleChannelClick = () => {}
 
-  // TODO: 각 섹션별로 받아온 채널 데이터를 map 으로 순회
+  // TODO: channel.type === DM 인 경우 Icon -> Avatar 분기처리
   return (
     <>
       <Styled.SectionContainer
@@ -75,16 +77,29 @@ const Section = ({ title, type }: SectionProps) => {
       <Styled.SectionChannelContainer>
         {toggle ? (
           <>
-            <M.ButtonDiv
-              buttonStyle={ChannelButtonStyle}
-              textStyle={ChannelTextStyle}
-              onClick={handleChannelClick}
-            >
-              <>
-                <A.Icon icon={myIcon.hashtag} customStyle={ChannelIconStyle} />
-                random
-              </>
-            </M.ButtonDiv>
+            {channelList.map((channel) => (
+              <Link
+                to={`/workspace/${workspaceId}/channel/${channel.id}`}
+                key={channel.id}
+              >
+                <M.ButtonDiv
+                  buttonStyle={ChannelButtonStyle}
+                  textStyle={ChannelTextStyle}
+                  onClick={handleChannelClick}
+                >
+                  <>
+                    {/* { channel.type === 'DM' ? <O.Avatar size={"MEDIUM"} user={}/>  : }  */}
+                    <A.Icon
+                      icon={
+                        channel.type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock
+                      }
+                      customStyle={ChannelIconStyle}
+                    />
+                    {channel.name}
+                  </>
+                </M.ButtonDiv>
+              </Link>
+            ))}
             {type === 'CHANNEL' ? (
               <M.ButtonDiv
                 buttonStyle={ChannelButtonStyle}

--- a/client/src/component/molecule/Section/index.ts
+++ b/client/src/component/molecule/Section/index.ts
@@ -1,6 +1,10 @@
+import { ChannelResponseType } from '@store/reducer/channel.reducer'
+
 export { default } from './Section'
 
 export interface SectionProps {
   title: string
   type: 'CHANNEL' | 'DM'
+  channelList: ChannelResponseType[]
+  workspaceId: number
 }

--- a/client/src/component/organism/SideBar/SideBar.style.ts
+++ b/client/src/component/organism/SideBar/SideBar.style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 const ScrollContainer = styled.div`
-  height: 90vh;
+  height: 85vh;
   overflow-y: scroll;
 `
 

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -12,7 +12,6 @@ interface SideBarProps {
 }
 
 const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
-  console.log(workspaceInfo, channelList)
   return (
     <Styled.SideBarContainer>
       <Styled.WorkSpacePart>
@@ -78,8 +77,19 @@ const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
           </M.ButtonDiv>
         </Styled.OtherPagePart>
         <Styled.SectionChannelPart>
-          <M.Section title="Channels" type="CHANNEL" />
-          <M.Section title="Direct Messages" type="DM" />
+          <M.Section
+            title="Channels"
+            type="CHANNEL"
+            workspaceId={workspaceInfo ? workspaceInfo.id : 1}
+            channelList={channelList.filter((channel) => channel.type !== 'DM')}
+          />
+
+          <M.Section
+            title="Direct Messages"
+            type="DM"
+            workspaceId={workspaceInfo ? workspaceInfo.id : 1}
+            channelList={channelList.filter((channel) => channel.type === 'DM')}
+          />
         </Styled.SectionChannelPart>
       </Styled.ScrollContainer>
     </Styled.SideBarContainer>

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -72,32 +72,6 @@ const SideBar = () => {
         <Styled.SectionChannelPart>
           <M.Section title="Channels" type="CHANNEL" />
           <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
-          <M.Section title="Direct Messages" type="DM" />
         </Styled.SectionChannelPart>
       </Styled.ScrollContainer>
     </Styled.SideBarContainer>

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -2,9 +2,17 @@ import React from 'react'
 import A from '@atom'
 import M from '@molecule'
 import myIcon from '@constant/icon'
+import { ChannelResponseType } from '@store/reducer/channel.reducer'
+import { WorkspaceResponseType } from '@store/reducer/workspace.reducer'
 import Styled from './SideBar.style'
 
-const SideBar = () => {
+interface SideBarProps {
+  workspaceInfo: WorkspaceResponseType | null
+  channelList: ChannelResponseType[]
+}
+
+const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
+  console.log(workspaceInfo, channelList)
   return (
     <Styled.SideBarContainer>
       <Styled.WorkSpacePart>

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -14,9 +14,10 @@ interface MatchParamsType {
 }
 
 const WorkspacePage = () => {
-  const { channelList, loading, error } = useSelector(
+  const { channelList, workspaceInfo, loading, error } = useSelector(
     (state: RootState) => state.channelStore,
   )
+
   const dispatch = useDispatch()
   const { workspaceId } = useParams<MatchParamsType>()
 
@@ -40,7 +41,7 @@ const WorkspacePage = () => {
       <O.Header />
 
       <WorkspaceLayout>
-        <O.SideBar />
+        <O.SideBar workspaceInfo={workspaceInfo} channelList={channelList} />
 
         <ViewContainer>
           <Switch>

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -5,11 +5,20 @@ import {
   createAsyncAction,
 } from 'typesafe-actions'
 import { AxiosError } from 'axios'
+import { WorkspaceResponseType } from './workspace.reducer'
 
-export interface ChannelResponseType {}
+export interface ChannelResponseType {
+  id: number
+  name: string
+  type: 'PRIVATE' | 'PUBLIC' | 'DM'
+  createdAt: string
+  updatedAt: string
+  deletedAt?: string
+}
 
 export interface ChannelState {
   channelList: ChannelResponseType[]
+  workspaceInfo: WorkspaceResponseType | null
   loading: boolean
   error: AxiosError | null
 }
@@ -63,6 +72,7 @@ export type ChannelAction = ActionType<typeof actions>
 
 const initialState: ChannelState = {
   channelList: [],
+  workspaceInfo: null,
   loading: true,
   error: null,
 }


### PR DESCRIPTION
## Linked Issue
close #38 

## 공유할 사항 
- 해당 유저가 속해있는 채널리스트를 받아와서 DM, Private, Public 에 맞춰 사이드바에 렌더링합니다.
- 채널 클릭 시 해당하는 채널의 스레드를 보여줍니다.