### PR TITLE
type 파일 분리, Redux 코드 리펙토링(clean up)

### DIFF
--- a/client/src/component/molecule/Section/index.ts
+++ b/client/src/component/molecule/Section/index.ts
@@ -1,4 +1,4 @@
-import { ChannelResponseType } from '@store/reducer/channel.reducer'
+import { ChannelResponseType } from '@type/channel.type'
 
 export { default } from './Section'
 

--- a/client/src/component/organism/ChannelHeader/index.ts
+++ b/client/src/component/organism/ChannelHeader/index.ts
@@ -1,4 +1,4 @@
-import { GetChannelInfoResponseType } from '@store/reducer/thread.reducer'
+import { GetChannelInfoResponseType } from '@type/thread.type'
 
 export { default } from './ChannelHeader'
 

--- a/client/src/component/organism/MessageCard/MessageCard.tsx
+++ b/client/src/component/organism/MessageCard/MessageCard.tsx
@@ -6,42 +6,9 @@ import myIcon from '@constant/icon'
 import { TextType } from '@atom/Text'
 import { IconType } from '@atom/Icon'
 import ActionBar from '@organism/ActionBar'
-import {
-  GetThreadResponseType,
-  MessageType,
-} from '@store/reducer/thread.reducer'
+import { GetThreadResponseType, MessageType } from '@type/thread.type'
 import { getTimePassedFromNow, getDateAndTime } from '@util/date'
 import Styled from './MessageCard.style'
-
-interface UserType {
-  id: number
-  email: string
-  name: string
-  profileImageUrl: string
-}
-
-// interface MessageType {
-//   id: number
-//   content: string
-//   isHead: boolean
-//   createdAt: string
-//   updatedAt: string
-//   User: UserType
-//   Files: object[]
-//   Reactions: {
-//     id: number
-//     content: string
-//     User: UserType
-//   }[]
-// }
-
-interface ThreadType {
-  id: number
-  createdAt: string
-  updatedAt: string
-  Messages: MessageType[]
-  User: UserType
-}
 
 interface MessageCardProps {
   data: GetThreadResponseType | MessageType

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import A from '@atom'
 import M from '@molecule'
 import myIcon from '@constant/icon'
-import { ChannelResponseType } from '@store/reducer/channel.reducer'
+import { ChannelResponseType } from '@type/channel.type'
 import { WorkspaceResponseType } from '@type/workspace.type'
 import Styled from './SideBar.style'
 

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -3,7 +3,7 @@ import A from '@atom'
 import M from '@molecule'
 import myIcon from '@constant/icon'
 import { ChannelResponseType } from '@store/reducer/channel.reducer'
-import { WorkspaceResponseType } from '@store/reducer/workspace.reducer'
+import { WorkspaceResponseType } from '@type/workspace.type'
 import Styled from './SideBar.style'
 
 interface SideBarProps {

--- a/client/src/component/organism/ThreadDetail/index.ts
+++ b/client/src/component/organism/ThreadDetail/index.ts
@@ -1,4 +1,4 @@
-import { MessageType } from '@store/reducer/thread.reducer'
+import { MessageType } from '@type/thread.type'
 
 export { default } from './ThreadDetail'
 
@@ -13,21 +13,6 @@ interface UserType {
   name: string
   profileImageUrl: string
 }
-
-// interface MessageType {
-//   id: number
-//   content: string
-//   isHead: boolean
-//   createdAt: string
-//   updatedAt: string
-//   User: UserType
-//   Files: object[]
-//   Reactions: {
-//     id: number
-//     content: string
-//     User: UserType
-//   }[]
-// }
 
 interface ThreadType {
   id: number

--- a/client/src/component/organism/ThreadList/index.ts
+++ b/client/src/component/organism/ThreadList/index.ts
@@ -3,7 +3,7 @@ import React from 'react'
 import {
   GetChannelInfoResponseType,
   GetThreadResponseType,
-} from '@store/reducer/thread.reducer'
+} from '@type/thread.type'
 
 export { default } from './ThreadList'
 

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -5,7 +5,7 @@ import M from '@molecule'
 import O from '@organism'
 import styled from 'styled-components'
 import { RootState } from '@store'
-import { getChannelsAsync } from '@store/reducer/channel.reducer'
+import { getChannels } from '@store/reducer/channel.reducer'
 import { connectSocket } from '@store/reducer/socket.reducer'
 import { Channel, ChannelBrowser } from './template'
 
@@ -31,7 +31,7 @@ const WorkspacePage = () => {
   const handleSubViewBody = (node: React.ReactNode) => setSubViewBody(node)
 
   useEffect(() => {
-    dispatch(getChannelsAsync.request({ workspaceId: +workspaceId }))
+    dispatch(getChannels.request({ workspaceId: +workspaceId }))
     localStorage.setItem('workspaceId', workspaceId)
     // TODO: workspaceId 생성 후 connectSocket 연결
     dispatch(connectSocket.request())

--- a/client/src/page/Workspace/template/Channel.tsx
+++ b/client/src/page/Workspace/template/Channel.tsx
@@ -35,8 +35,8 @@ const Channel = ({
   console.log(`channelId: ${channelId}`)
 
   useEffect(() => {
-    dispatch(getChannelInfoAsync.request(+channelId))
-    dispatch(getThreadsAsync.request(+channelId))
+    dispatch(getChannelInfoAsync.request({ channelId: +channelId }))
+    dispatch(getThreadsAsync.request({ channelId: +channelId }))
   }, [])
 
   return (

--- a/client/src/page/WorkspaceBrowser/NewWorkspacePage.tsx
+++ b/client/src/page/WorkspaceBrowser/NewWorkspacePage.tsx
@@ -14,7 +14,7 @@ const NewWorkspacePage = () => {
   const handleNewWorkspaceInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     if (name === 'workspaceName') setWorkspaceName(value)
-    if (name === 'workspaceImgaeUrl') setWorkspaceImageUrl(value)
+    if (name === 'workspaceImageUrl') setWorkspaceImageUrl(value)
   }
 
   const handleClickCreateNewWorkspace = () => {
@@ -32,7 +32,7 @@ const NewWorkspacePage = () => {
       />
 
       <A.Input
-        name="workspaceImgaeUrl"
+        name="workspaceImageUrl"
         onChange={handleNewWorkspaceInput}
         value={workspaceImageUrl}
       />

--- a/client/src/page/WorkspaceBrowser/WorkspaceBrowserPage.tsx
+++ b/client/src/page/WorkspaceBrowser/WorkspaceBrowserPage.tsx
@@ -4,14 +4,14 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import { RootState } from '@store'
 import { useSelector, useDispatch } from 'react-redux'
-import { getWorkspaceAsync } from '@store/reducer/workspace.reducer'
+import { getWorkspace } from '@store/reducer/workspace.reducer'
 
 const WorkspaceBrowserPage = () => {
   const workspaceStore = useSelector((state: RootState) => state.workspaceStore)
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(getWorkspaceAsync.request())
+    dispatch(getWorkspace.request())
   }, [])
 
   return (

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -5,7 +5,7 @@ import {
   createAsyncAction,
 } from 'typesafe-actions'
 import { AxiosError } from 'axios'
-import { WorkspaceResponseType } from './workspace.reducer'
+import { WorkspaceResponseType } from '@type/workspace.type'
 
 export interface ChannelResponseType {
   id: number

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -20,39 +20,6 @@ export interface ChannelState {
   error: AxiosError | null
 }
 
-export const GET_CHANNELS = 'channel/GET_CHANNELS' as const
-const GET_CHANNELS_SUCCESS = 'channel/GET_CHANNELS_SUCCESS' as const
-const GET_CHANNELS_ERROR = 'channel/GET_CHANNELS_ERROR' as const
-
-export const CREATE_CHANNEL = 'channel/CREATE_CHANNEL'
-export const JOIN_CHANNEL = 'channel/JOIN_CHANNEL'
-
-export const getChannels = createAction(GET_CHANNELS)<ChannelRequestType>()
-export const getChannelsSuccess = createAction(GET_CHANNELS_SUCCESS)<
-  ChannelResponseType[]
->()
-export const getChannelsError = createAction(GET_CHANNELS_ERROR)<AxiosError>()
-export const createChannel = createAction(CREATE_CHANNEL)<
-  CreateChannelRequestType
->()
-export const joinChannel = createAction(JOIN_CHANNEL)<JoinChannelRequestType>()
-
-export const getChannelsAsync = createAsyncAction(
-  GET_CHANNELS,
-  GET_CHANNELS_SUCCESS,
-  GET_CHANNELS_ERROR,
-)<ChannelRequestType, ChannelResponseType[], AxiosError>()
-
-const actions = {
-  getChannels,
-  getChannelsSuccess,
-  getChannelsError,
-  createChannel,
-  joinChannel,
-}
-
-export type ChannelAction = ActionType<typeof actions>
-
 const initialState: ChannelState = {
   channelList: [],
   workspaceInfo: null,
@@ -60,8 +27,34 @@ const initialState: ChannelState = {
   error: null,
 }
 
+export const GET_CHANNELS_REQUEST = 'channel/GET_CHANNELS_REQUEST' as const
+const GET_CHANNELS_SUCCESS = 'channel/GET_CHANNELS_SUCCESS' as const
+const GET_CHANNELS_ERROR = 'channel/GET_CHANNELS_ERROR' as const
+export const CREATE_CHANNEL = 'channel/CREATE_CHANNEL' as const
+export const JOIN_CHANNEL = 'channel/JOIN_CHANNEL' as const
+
+export const getChannels = createAsyncAction(
+  GET_CHANNELS_REQUEST,
+  GET_CHANNELS_SUCCESS,
+  GET_CHANNELS_ERROR,
+)<ChannelRequestType, ChannelResponseType[], AxiosError>()
+export const createChannel = createAction(CREATE_CHANNEL)<
+  CreateChannelRequestType
+>()
+export const joinChannel = createAction(JOIN_CHANNEL)<JoinChannelRequestType>()
+
+const actions = {
+  getChannelsRequest: getChannels.request,
+  getChannelsSuccess: getChannels.success,
+  getChannelsError: getChannels.failure,
+  createChannel,
+  joinChannel,
+}
+
+export type ChannelAction = ActionType<typeof actions>
+
 const reducer = createReducer<ChannelState, ChannelAction>(initialState, {
-  [GET_CHANNELS]: (state, action) => ({
+  [GET_CHANNELS_REQUEST]: (state, _) => ({
     ...state,
     loading: true,
     error: null,

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -6,35 +6,18 @@ import {
 } from 'typesafe-actions'
 import { AxiosError } from 'axios'
 import { WorkspaceResponseType } from '@type/workspace.type'
-
-export interface ChannelResponseType {
-  id: number
-  name: string
-  type: 'PRIVATE' | 'PUBLIC' | 'DM'
-  createdAt: string
-  updatedAt: string
-  deletedAt?: string
-}
+import {
+  ChannelRequestType,
+  ChannelResponseType,
+  CreateChannelRequestType,
+  JoinChannelRequestType,
+} from '@type/channel.type'
 
 export interface ChannelState {
   channelList: ChannelResponseType[]
   workspaceInfo: WorkspaceResponseType | null
   loading: boolean
   error: AxiosError | null
-}
-
-export interface CreateChannelRequestType {
-  name: string
-  imageUrl: string
-}
-
-export interface JoinChannelRequestType {
-  channelId: number
-  userId: number
-}
-
-interface ChannelRequestType {
-  workspaceId?: number
 }
 
 export const GET_CHANNELS = 'channel/GET_CHANNELS' as const

--- a/client/src/store/reducer/socket.reducer.ts
+++ b/client/src/store/reducer/socket.reducer.ts
@@ -34,7 +34,9 @@ export const sendSocketJoinRoom = createAction(SEND_SOCKET_JOIN_ROOM)<{
 }>()
 
 const actions = {
-  ...connectSocket,
+  connectSocketRequest: connectSocket.request,
+  connectSocketSuccess: connectSocket.success,
+  connectSocketFailure: connectSocket.failure,
   sendSocketCreateThread,
   sendSocketJoinRoom,
 }

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -41,27 +41,32 @@ export const GET_CHANNEL_INFO_REQUEST = 'thread/GET_CHANNEL_INFO_REQUEST' as con
 const GET_CHANNEL_INFO_SUCCESS = 'thread/GET_CHANNEL_INFO_SUCCESS' as const
 const GET_CHANNEL_INFO_ERROR = 'thread/GET_CHANNEL_INFO_ERROR' as const
 
-const getThreadsRequest = createAction(GET_THREADS_REQUEST)<number>()
-const getThreadsSuccess = createAction(GET_THREADS_SUCCESS)<
-  GetThreadResponseType[]
->()
-const getThreadsError = createAction(GET_THREADS_ERROR)<AxiosError>()
+// const getThreadsRequest = createAction(GET_THREADS_REQUEST)<number>()
+// const getThreadsSuccess = createAction(GET_THREADS_SUCCESS)<
+//   GetThreadResponseType[]
+// >()
+// const getThreadsError = createAction(GET_THREADS_ERROR)<AxiosError>()
 export const createThread = createAction(CREATE_THREAD)<
   CreateThreadRequestType
 >()
 export const receiveCreateThread = createAction(RECEIVE_CREATE_THREAD)<
   GetThreadResponseType
 >()
-const getChannelInfoRequest = createAction(GET_CHANNEL_INFO_REQUEST)<number>()
-const getChannelInfoSuccess = createAction(GET_CHANNEL_INFO_SUCCESS)<
-  GetChannelInfoResponseType
->()
-const getChannelInfoError = createAction(GET_CHANNEL_INFO_ERROR)<AxiosError>()
+// const getChannelInfoRequest = createAction(GET_CHANNEL_INFO_REQUEST)<number>()
+// const getChannelInfoSuccess = createAction(GET_CHANNEL_INFO_SUCCESS)<
+//   GetChannelInfoResponseType
+// >()
+// const getChannelInfoError = createAction(GET_CHANNEL_INFO_ERROR)<AxiosError>()
 export const getThreadsAsync = createAsyncAction(
   GET_THREADS_REQUEST,
   GET_THREADS_SUCCESS,
   GET_THREADS_ERROR,
 )<number, GetThreadResponseType[], AxiosError>()
+// const {
+//   request: getThreadsRequest,
+//   success: getThreadsSuccess,
+//   failure: getThreadsError,
+// } = getThreadsAsync
 export const getChannelInfoAsync = createAsyncAction(
   GET_CHANNEL_INFO_REQUEST,
   GET_CHANNEL_INFO_SUCCESS,
@@ -69,14 +74,14 @@ export const getChannelInfoAsync = createAsyncAction(
 )<number, GetChannelInfoResponseType, AxiosError>()
 
 const actions = {
-  getThreadsRequest,
-  getThreadsSuccess,
-  getThreadsError,
+  getThreadsRequest: getThreadsAsync.request,
+  getThreadsSuccess: getThreadsAsync.success,
+  getThreadsError: getThreadsAsync.failure,
   createThread,
   receiveCreateThread,
-  getChannelInfoRequest,
-  getChannelInfoSuccess,
-  getChannelInfoError,
+  getChannelInfoRequest: getChannelInfoAsync.request,
+  getChannelInfoSuccess: getChannelInfoAsync.success,
+  getChannelInfoError: getChannelInfoAsync.failure,
 }
 
 export type ThreadAction = ActionType<typeof actions>

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -33,13 +33,13 @@ const initialState: ThreadState = {
 }
 
 export const GET_THREADS_REQUEST = 'thread/GET_THREADS_REQUEST' as const
-export const GET_THREADS_SUCCESS = 'thread/GET_THREADS_SUCCESS' as const
-export const GET_THREADS_ERROR = 'thread/GET_THREADS_ERROR' as const
+const GET_THREADS_SUCCESS = 'thread/GET_THREADS_SUCCESS' as const
+const GET_THREADS_ERROR = 'thread/GET_THREADS_ERROR' as const
 export const CREATE_THREAD = 'thread/CREATE_THREAD' as const
 export const RECEIVE_CREATE_THREAD = 'thread/RECEIVE_CREATE_THREAD' as const
 export const GET_CHANNEL_INFO_REQUEST = 'thread/GET_CHANNEL_INFO_REQUEST' as const
-export const GET_CHANNEL_INFO_SUCCESS = 'thread/GET_CHANNEL_INFO_SUCCESS' as const
-export const GET_CHANNEL_INFO_ERROR = 'thread/GET_CHANNEL_INFO_ERROR' as const
+const GET_CHANNEL_INFO_SUCCESS = 'thread/GET_CHANNEL_INFO_SUCCESS' as const
+const GET_CHANNEL_INFO_ERROR = 'thread/GET_CHANNEL_INFO_ERROR' as const
 
 const getThreadsRequest = createAction(GET_THREADS_REQUEST)<number>()
 const getThreadsSuccess = createAction(GET_THREADS_SUCCESS)<

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -5,75 +5,11 @@ import {
   createAsyncAction,
 } from 'typesafe-actions'
 import { AxiosError } from 'axios'
-
-interface UserType {
-  id: number
-  email: string
-  name: string
-  profileImageUrl: string
-}
-
-interface FileType {
-  id: number
-  url: string
-  type: string
-  createdAt: string
-  updatedAt: string
-  profileImageUrl: string
-}
-
-interface ReactionType {
-  id: number
-  content: string
-  User: UserType
-}
-
-export interface ThreadType {
-  id: number
-  createdAt: string
-  updatedAt: string
-  messageCount: number
-  profileImageUrl: string[] | null
-  User: UserType
-}
-
-export interface MessageType {
-  id: number
-  content: string
-  isHead: true
-  createdAt: string
-  updatedAt: string
-  User: UserType
-  File: FileType[]
-  Reactions: ReactionType[]
-}
-
-export interface GetThreadResponseType {
-  id: number
-  createdAt: string
-  updatedAt: string
-  User: UserType
-  headMessage: MessageType
-  replyCount: number
-  userProfileMax5: string[]
-  commenterCount: number
-  lastReplyTime: string
-}
-
-export interface CreateThreadRequestType {
-  content: string
-  channelId: number
-  fileInfoList: { filePath: string; type: string }[] | null
-}
-
-export interface GetChannelInfoResponseType extends Object {
-  id: number
-  type: string
-  name: string
-  createdAt: string
-  updatedAt: string
-  user: UserType[]
-}
+import {
+  GetThreadResponseType,
+  GetChannelInfoResponseType,
+  CreateThreadRequestType,
+} from '@type/thread.type'
 
 interface ThreadState {
   channelInfo: GetChannelInfoResponseType
@@ -82,62 +18,6 @@ interface ThreadState {
   error: AxiosError | null
 }
 
-// Action
-export const GET_THREADS = 'thread/GET_THREADS' as const
-export const GET_THREADS_SUCCESS = 'thread/GET_THREADS_SUCCESS' as const
-export const GET_THREADS_ERROR = 'thread/GET_THREADS_ERROR' as const
-export const CREATE_THREAD = 'thread/CREATE_THREAD' as const
-export const RECEIVE_CREATE_THREAD = 'thread/RECEIVE_CREATE_THREAD' as const
-export const GET_CHANNEL_INFO = 'thread/GET_CHANNEL_INFO' as const
-export const GET_CHANNEL_INFO_SUCCESS = 'thread/GET_CHANNEL_INFO_SUCCESS' as const
-export const GET_CHANNEL_INFO_ERROR = 'thread/GET_CHANNEL_INFO_ERROR' as const
-
-// Action generator
-export const getThreads = createAction(GET_THREADS)<number>()
-export const getThreadsSuccess = createAction(GET_THREADS_SUCCESS)<
-  GetThreadResponseType[]
->()
-export const getThreadsError = createAction(GET_THREADS_ERROR)<AxiosError>()
-export const createThread = createAction(CREATE_THREAD)<
-  CreateThreadRequestType
->()
-export const receiveCreateThread = createAction(RECEIVE_CREATE_THREAD)<
-  GetThreadResponseType
->()
-export const getChannelInfo = createAction(GET_CHANNEL_INFO)<number>()
-export const getChannelInfoSuccess = createAction(GET_CHANNEL_INFO_SUCCESS)<
-  GetChannelInfoResponseType
->()
-export const getChannelInfoError = createAction(GET_CHANNEL_INFO_ERROR)<
-  AxiosError
->()
-
-export const getThreadsAsync = createAsyncAction(
-  GET_THREADS,
-  GET_THREADS_SUCCESS,
-  GET_THREADS_ERROR,
-)<number, GetThreadResponseType[], AxiosError>()
-
-export const getChannelInfoAsync = createAsyncAction(
-  GET_CHANNEL_INFO,
-  GET_CHANNEL_INFO_SUCCESS,
-  GET_CHANNEL_INFO_ERROR,
-)<number, GetChannelInfoResponseType, AxiosError>()
-
-// action
-const actions = {
-  getThreads,
-  getThreadsSuccess,
-  getThreadsError,
-  createThread,
-  receiveCreateThread,
-  getChannelInfo,
-  getChannelInfoSuccess,
-  getChannelInfoError,
-}
-export type ThreadAction = ActionType<typeof actions>
-
-// initial state
 const initialState: ThreadState = {
   channelInfo: {
     id: 0,
@@ -152,8 +32,57 @@ const initialState: ThreadState = {
   error: null,
 }
 
+export const GET_THREADS_REQUEST = 'thread/GET_THREADS_REQUEST' as const
+export const GET_THREADS_SUCCESS = 'thread/GET_THREADS_SUCCESS' as const
+export const GET_THREADS_ERROR = 'thread/GET_THREADS_ERROR' as const
+export const CREATE_THREAD = 'thread/CREATE_THREAD' as const
+export const RECEIVE_CREATE_THREAD = 'thread/RECEIVE_CREATE_THREAD' as const
+export const GET_CHANNEL_INFO_REQUEST = 'thread/GET_CHANNEL_INFO_REQUEST' as const
+export const GET_CHANNEL_INFO_SUCCESS = 'thread/GET_CHANNEL_INFO_SUCCESS' as const
+export const GET_CHANNEL_INFO_ERROR = 'thread/GET_CHANNEL_INFO_ERROR' as const
+
+const getThreadsRequest = createAction(GET_THREADS_REQUEST)<number>()
+const getThreadsSuccess = createAction(GET_THREADS_SUCCESS)<
+  GetThreadResponseType[]
+>()
+const getThreadsError = createAction(GET_THREADS_ERROR)<AxiosError>()
+export const createThread = createAction(CREATE_THREAD)<
+  CreateThreadRequestType
+>()
+export const receiveCreateThread = createAction(RECEIVE_CREATE_THREAD)<
+  GetThreadResponseType
+>()
+const getChannelInfoRequest = createAction(GET_CHANNEL_INFO_REQUEST)<number>()
+const getChannelInfoSuccess = createAction(GET_CHANNEL_INFO_SUCCESS)<
+  GetChannelInfoResponseType
+>()
+const getChannelInfoError = createAction(GET_CHANNEL_INFO_ERROR)<AxiosError>()
+export const getThreadsAsync = createAsyncAction(
+  GET_THREADS_REQUEST,
+  GET_THREADS_SUCCESS,
+  GET_THREADS_ERROR,
+)<number, GetThreadResponseType[], AxiosError>()
+export const getChannelInfoAsync = createAsyncAction(
+  GET_CHANNEL_INFO_REQUEST,
+  GET_CHANNEL_INFO_SUCCESS,
+  GET_CHANNEL_INFO_ERROR,
+)<number, GetChannelInfoResponseType, AxiosError>()
+
+const actions = {
+  getThreadsRequest,
+  getThreadsSuccess,
+  getThreadsError,
+  createThread,
+  receiveCreateThread,
+  getChannelInfoRequest,
+  getChannelInfoSuccess,
+  getChannelInfoError,
+}
+
+export type ThreadAction = ActionType<typeof actions>
+
 const reducer = createReducer<ThreadState, ThreadAction>(initialState, {
-  [GET_THREADS]: (state, action) => ({
+  [GET_THREADS_REQUEST]: (state, _) => ({
     ...state,
     loading: true,
     error: null,
@@ -174,7 +103,7 @@ const reducer = createReducer<ThreadState, ThreadAction>(initialState, {
     ...state,
     threadList: [...state.threadList, action.payload],
   }),
-  [GET_CHANNEL_INFO]: (state, action) => ({
+  [GET_CHANNEL_INFO_REQUEST]: (state, _) => ({
     ...state,
     loading: true,
     error: null,

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -41,32 +41,17 @@ export const GET_CHANNEL_INFO_REQUEST = 'thread/GET_CHANNEL_INFO_REQUEST' as con
 const GET_CHANNEL_INFO_SUCCESS = 'thread/GET_CHANNEL_INFO_SUCCESS' as const
 const GET_CHANNEL_INFO_ERROR = 'thread/GET_CHANNEL_INFO_ERROR' as const
 
-// const getThreadsRequest = createAction(GET_THREADS_REQUEST)<number>()
-// const getThreadsSuccess = createAction(GET_THREADS_SUCCESS)<
-//   GetThreadResponseType[]
-// >()
-// const getThreadsError = createAction(GET_THREADS_ERROR)<AxiosError>()
+export const getThreadsAsync = createAsyncAction(
+  GET_THREADS_REQUEST,
+  GET_THREADS_SUCCESS,
+  GET_THREADS_ERROR,
+)<number, GetThreadResponseType[], AxiosError>()
 export const createThread = createAction(CREATE_THREAD)<
   CreateThreadRequestType
 >()
 export const receiveCreateThread = createAction(RECEIVE_CREATE_THREAD)<
   GetThreadResponseType
 >()
-// const getChannelInfoRequest = createAction(GET_CHANNEL_INFO_REQUEST)<number>()
-// const getChannelInfoSuccess = createAction(GET_CHANNEL_INFO_SUCCESS)<
-//   GetChannelInfoResponseType
-// >()
-// const getChannelInfoError = createAction(GET_CHANNEL_INFO_ERROR)<AxiosError>()
-export const getThreadsAsync = createAsyncAction(
-  GET_THREADS_REQUEST,
-  GET_THREADS_SUCCESS,
-  GET_THREADS_ERROR,
-)<number, GetThreadResponseType[], AxiosError>()
-// const {
-//   request: getThreadsRequest,
-//   success: getThreadsSuccess,
-//   failure: getThreadsError,
-// } = getThreadsAsync
 export const getChannelInfoAsync = createAsyncAction(
   GET_CHANNEL_INFO_REQUEST,
   GET_CHANNEL_INFO_SUCCESS,

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -45,7 +45,7 @@ export const getThreadsAsync = createAsyncAction(
   GET_THREADS_REQUEST,
   GET_THREADS_SUCCESS,
   GET_THREADS_ERROR,
-)<number, GetThreadResponseType[], AxiosError>()
+)<{ channelId: number }, GetThreadResponseType[], AxiosError>()
 export const createThread = createAction(CREATE_THREAD)<
   CreateThreadRequestType
 >()
@@ -56,7 +56,7 @@ export const getChannelInfoAsync = createAsyncAction(
   GET_CHANNEL_INFO_REQUEST,
   GET_CHANNEL_INFO_SUCCESS,
   GET_CHANNEL_INFO_ERROR,
-)<number, GetChannelInfoResponseType, AxiosError>()
+)<{ channelId: number }, GetChannelInfoResponseType, AxiosError>()
 
 const actions = {
   getThreadsRequest: getThreadsAsync.request,

--- a/client/src/store/reducer/workspace.reducer.ts
+++ b/client/src/store/reducer/workspace.reducer.ts
@@ -11,46 +11,11 @@ import {
   JoinWorkspaceRequestType,
 } from '@type/workspace.type'
 
-export interface WorkspaceState {
+interface WorkspaceState {
   workspaceList: WorkspaceResponseType[]
   loading: boolean
   error: AxiosError | null
 }
-
-export const GET_WORKSPACES = 'workspace/GET_WORKSPACES' as const
-const GET_WORKSPACES_SUCCESS = 'workspace/GET_WORKSPACES_SUCCESS' as const
-const GET_WORKSPACES_ERROR = 'workspace/GET_WORKSPACES_ERROR' as const
-export const CREATE_WORKSPACE = 'workspace/CREATE_WORKSPACE' as const
-export const JOIN_WORKSPACE = 'workspace/JOIN_WORKSPACE' as const
-
-export const getWorkspaces = createAction(GET_WORKSPACES)()
-export const getWorkspacesSuccess = createAction(GET_WORKSPACES_SUCCESS)<
-  WorkspaceResponseType[]
->()
-export const getWorkspacesError = createAction(GET_WORKSPACES_ERROR)<
-  AxiosError
->()
-export const createWorkspace = createAction(CREATE_WORKSPACE)<
-  CreateWorkspaceRequestType
->()
-export const joinWorkspace = createAction(JOIN_WORKSPACE)<
-  JoinWorkspaceRequestType
->()
-
-export const getWorkspaceAsync = createAsyncAction(
-  GET_WORKSPACES,
-  GET_WORKSPACES_SUCCESS,
-  GET_WORKSPACES_ERROR,
-)<undefined, WorkspaceResponseType[], AxiosError>()
-
-const actions = {
-  getWorkspaces,
-  getWorkspacesSuccess,
-  getWorkspacesError,
-  createWorkspace,
-  joinWorkspace,
-}
-export type WorkspaceAction = ActionType<typeof actions>
 
 const initialState: WorkspaceState = {
   workspaceList: [],
@@ -58,8 +23,34 @@ const initialState: WorkspaceState = {
   error: null,
 }
 
+export const GET_WORKSPACES_REQUEST = 'workspace/GET_WORKSPACES' as const
+const GET_WORKSPACES_SUCCESS = 'workspace/GET_WORKSPACES_SUCCESS' as const
+const GET_WORKSPACES_ERROR = 'workspace/GET_WORKSPACES_ERROR' as const
+export const CREATE_WORKSPACE = 'workspace/CREATE_WORKSPACE' as const
+export const JOIN_WORKSPACE = 'workspace/JOIN_WORKSPACE' as const
+
+export const getWorkspace = createAsyncAction(
+  GET_WORKSPACES_REQUEST,
+  GET_WORKSPACES_SUCCESS,
+  GET_WORKSPACES_ERROR,
+)<undefined, WorkspaceResponseType[], AxiosError>()
+export const createWorkspace = createAction(CREATE_WORKSPACE)<
+  CreateWorkspaceRequestType
+>()
+export const joinWorkspace = createAction(JOIN_WORKSPACE)<
+  JoinWorkspaceRequestType
+>()
+
+const actions = {
+  ...getWorkspace,
+  createWorkspace,
+  joinWorkspace,
+}
+
+export type WorkspaceAction = ActionType<typeof actions>
+
 const reducer = createReducer<WorkspaceState, WorkspaceAction>(initialState, {
-  [GET_WORKSPACES]: (state, action) => ({
+  [GET_WORKSPACES_REQUEST]: (state, _) => ({
     ...state,
     loading: true,
     error: null,

--- a/client/src/store/reducer/workspace.reducer.ts
+++ b/client/src/store/reducer/workspace.reducer.ts
@@ -42,7 +42,9 @@ export const joinWorkspace = createAction(JOIN_WORKSPACE)<
 >()
 
 const actions = {
-  ...getWorkspace,
+  getWorkspacesRequest: getWorkspace.request,
+  getWorkspacesSuccess: getWorkspace.success,
+  getWorkspacesFailure: getWorkspace.failure,
   createWorkspace,
   joinWorkspace,
 }

--- a/client/src/store/reducer/workspace.reducer.ts
+++ b/client/src/store/reducer/workspace.reducer.ts
@@ -5,21 +5,11 @@ import {
   createAsyncAction,
 } from 'typesafe-actions'
 import { AxiosError } from 'axios'
-
-export interface WorkspaceResponseType extends Object {
-  id: number
-  name: string
-  imageUrl: string
-}
-
-export interface CreateWorkspaceRequestType {
-  name: string
-  imageUrl: string
-}
-
-export interface JoinWorkspaceRequestType {
-  workspaceId: number
-}
+import {
+  WorkspaceResponseType,
+  CreateWorkspaceRequestType,
+  JoinWorkspaceRequestType,
+} from '@type/workspace.type'
 
 export interface WorkspaceState {
   workspaceList: WorkspaceResponseType[]

--- a/client/src/store/saga/channel.saga.ts
+++ b/client/src/store/saga/channel.saga.ts
@@ -2,22 +2,21 @@ import { call, put, takeEvery, fork, all } from 'redux-saga/effects'
 import { toast } from 'react-toastify'
 import channelAPI from '@api/channel'
 import {
-  getChannelsAsync,
+  GET_CHANNELS_REQUEST,
+  CREATE_CHANNEL,
+  JOIN_CHANNEL,
   getChannels,
   createChannel,
   joinChannel,
-  GET_CHANNELS,
-  CREATE_CHANNEL,
-  JOIN_CHANNEL,
 } from '../reducer/channel.reducer'
 
-function* getChannelsSaga(action: ReturnType<typeof getChannelsAsync.request>) {
+function* getChannelsSaga(action: ReturnType<typeof getChannels.request>) {
   try {
     const { success, data } = yield call(channelAPI.getChannels, action.payload)
     if (success) console.log(data)
-    yield put(getChannelsAsync.success(data))
+    yield put(getChannels.success(data))
   } catch (error) {
-    yield put(getChannelsAsync.failure(error))
+    yield put(getChannels.failure(error))
   }
 }
 
@@ -31,7 +30,7 @@ function* joinChannelSaga(action: ReturnType<typeof joinChannel>) {
 }
 
 function* watchGetChannelsSaga() {
-  yield takeEvery(GET_CHANNELS, getChannelsSaga)
+  yield takeEvery(GET_CHANNELS_REQUEST, getChannelsSaga)
 }
 
 function* watchJoinChannelSaga() {

--- a/client/src/store/saga/socket.saga.ts
+++ b/client/src/store/saga/socket.saga.ts
@@ -2,10 +2,7 @@ import { fork, call, take, put, select } from 'redux-saga/effects'
 import { eventChannel } from 'redux-saga'
 import { io, Socket } from 'socket.io-client'
 import { receiveCreateThread } from '@store/reducer/thread.reducer'
-import {
-  getChannelsAsync,
-  ChannelResponseType,
-} from '@store/reducer/channel.reducer'
+import { ChannelResponseType } from '@type/channel.type'
 import { RootState } from '../index'
 import {
   connectSocket,

--- a/client/src/store/saga/thread.saga.ts
+++ b/client/src/store/saga/thread.saga.ts
@@ -19,7 +19,7 @@ function* getThreadsSaga(action: ReturnType<typeof getThreadsAsync.request>) {
   try {
     const threads: GetThreadResponseType[] = yield call(
       threadAPI.getThreads,
-      action.payload,
+      action.payload.channelId,
     )
     yield put(getThreadsAsync.success(threads))
   } catch (e) {
@@ -62,7 +62,7 @@ function* getCannelInfoSaga(
   try {
     const { success, data }: ChannelInfoResponseType = yield call(
       channelAPI.getChannelInfo,
-      action.payload,
+      action.payload.channelId,
     )
     if (success) yield put(getChannelInfoAsync.success(data))
   } catch (e) {

--- a/client/src/store/saga/thread.saga.ts
+++ b/client/src/store/saga/thread.saga.ts
@@ -2,12 +2,13 @@ import { call, put, takeEvery, fork, all } from 'redux-saga/effects'
 import threadAPI from '@api/thread'
 import channelAPI from '@api/channel'
 import {
-  // ThreadType,
   GetThreadResponseType,
-  GET_THREADS,
-  GET_CHANNEL_INFO,
-  CREATE_THREAD,
   GetChannelInfoResponseType,
+} from '@type/thread.type'
+import {
+  GET_THREADS_REQUEST,
+  GET_CHANNEL_INFO_REQUEST,
+  CREATE_THREAD,
   getThreadsAsync,
   getChannelInfoAsync,
   createThread,
@@ -70,7 +71,7 @@ function* getCannelInfoSaga(
 }
 
 function* watchGetThreadsSaga() {
-  yield takeEvery(GET_THREADS, getThreadsSaga)
+  yield takeEvery(GET_THREADS_REQUEST, getThreadsSaga)
 }
 
 function* watchCreateThreadSaga() {
@@ -78,7 +79,7 @@ function* watchCreateThreadSaga() {
 }
 
 function* watchGetCannelInfoSaga() {
-  yield takeEvery(GET_CHANNEL_INFO, getCannelInfoSaga)
+  yield takeEvery(GET_CHANNEL_INFO_REQUEST, getCannelInfoSaga)
 }
 
 export default function* threadSaga() {

--- a/client/src/store/saga/workspace.saga.ts
+++ b/client/src/store/saga/workspace.saga.ts
@@ -2,11 +2,11 @@ import { call, put, takeEvery, fork, all } from 'redux-saga/effects'
 import { toast } from 'react-toastify'
 import workspaceAPI from '@api/workspace'
 import {
-  getWorkspaceAsync,
-  createWorkspace,
-  GET_WORKSPACES,
+  GET_WORKSPACES_REQUEST,
   CREATE_WORKSPACE,
   JOIN_WORKSPACE,
+  getWorkspace,
+  createWorkspace,
   joinWorkspace,
 } from '../reducer/workspace.reducer'
 
@@ -14,10 +14,10 @@ function* getWorkspacesSaga() {
   try {
     const { success, data } = yield call(workspaceAPI.getWorkspace)
     if (success) console.log('workspace를 불러왔습니다.')
-    yield put(getWorkspaceAsync.success(data))
+    yield put(getWorkspace.success(data))
   } catch (error) {
     toast.error('Failed to read workspace')
-    yield put(getWorkspaceAsync.failure(error))
+    yield put(getWorkspace.failure(error))
   }
 }
 
@@ -47,7 +47,7 @@ function* joinWorkspaceSaga(action: ReturnType<typeof joinWorkspace>) {
 }
 
 function* watchGetWorkspacesSaga() {
-  yield takeEvery(GET_WORKSPACES, getWorkspacesSaga)
+  yield takeEvery(GET_WORKSPACES_REQUEST, getWorkspacesSaga)
 }
 
 function* watchCreateWorkspaceSaga() {

--- a/client/src/type/channel.type.ts
+++ b/client/src/type/channel.type.ts
@@ -1,0 +1,22 @@
+export interface ChannelResponseType {
+  id: number
+  name: string
+  type: 'PRIVATE' | 'PUBLIC' | 'DM'
+  createdAt: string
+  updatedAt: string
+  deletedAt?: string
+}
+
+export interface CreateChannelRequestType {
+  name: string
+  imageUrl: string
+}
+
+export interface JoinChannelRequestType {
+  channelId: number
+  userId: number
+}
+
+export interface ChannelRequestType {
+  workspaceId?: number
+}

--- a/client/src/type/thread.type.ts
+++ b/client/src/type/thread.type.ts
@@ -1,0 +1,63 @@
+import { UserType } from './user.type'
+
+interface FileType {
+  id: number
+  url: string
+  type: string
+  createdAt: string
+  updatedAt: string
+  profileImageUrl: string
+}
+
+interface ReactionType {
+  id: number
+  content: string
+  User: UserType
+}
+
+export interface ThreadType {
+  id: number
+  createdAt: string
+  updatedAt: string
+  messageCount: number
+  profileImageUrl: string[] | null
+  User: UserType
+}
+
+export interface MessageType {
+  id: number
+  content: string
+  isHead: true
+  createdAt: string
+  updatedAt: string
+  User: UserType
+  File: FileType[]
+  Reactions: ReactionType[]
+}
+
+export interface GetThreadResponseType {
+  id: number
+  createdAt: string
+  updatedAt: string
+  User: UserType
+  headMessage: MessageType
+  replyCount: number
+  userProfileMax5: string[]
+  commenterCount: number
+  lastReplyTime: string
+}
+
+export interface CreateThreadRequestType {
+  content: string
+  channelId: number
+  fileInfoList: { filePath: string; type: string }[] | null
+}
+
+export interface GetChannelInfoResponseType extends Object {
+  id: number
+  type: string
+  name: string
+  createdAt: string
+  updatedAt: string
+  user: UserType[]
+}

--- a/client/src/type/user.type.ts
+++ b/client/src/type/user.type.ts
@@ -1,0 +1,6 @@
+export interface UserType {
+  id: number
+  email: string
+  name: string
+  profileImageUrl: string
+}

--- a/client/src/type/workspace.type.ts
+++ b/client/src/type/workspace.type.ts
@@ -1,0 +1,14 @@
+export interface WorkspaceResponseType extends Object {
+  id: number
+  name: string
+  imageUrl: string
+}
+
+export interface CreateWorkspaceRequestType {
+  name: string
+  imageUrl: string
+}
+
+export interface JoinWorkspaceRequestType {
+  workspaceId: number
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -19,8 +19,8 @@
       "@molecule": ["src/component/molecule/index"],
       "@organism": ["src/component/organism/index"],
       "@store": ["src/store/index"],
-      "@page":["src/page/index"],
-      "@hook":["src/hoc/index"],
+      "@page": ["src/page/index"],
+      "@hook": ["src/hoc/index"],
 
       "@atom/*": ["src/component/atom/*"],
       "@molecule/*": ["src/component/molecule/*"],
@@ -31,7 +31,8 @@
       "@store/*": ["src/store/*"],
       "@util/*": ["src/util/*"],
       "@api/*": ["src/api/*"],
-      "@hoc/*":["src/hoc/*"],
+      "@hoc/*": ["src/hoc/*"],
+      "@type/*": ["src/type/*"]
     }
   },
   "exclude": ["node_modules"],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
       '@util': path.resolve(__dirname, 'src/util'),
       '@api': path.resolve(__dirname, 'src/api'),
       '@hoc': path.resolve(__dirname, 'src/hoc'),
+      '@type': path.resolve(__dirname, 'src/type'),
     },
   },
 


### PR DESCRIPTION
## 공유할 사항 
- store 폴더 안에 있는 모든 type을 `type/` 폴더 안으로 옮겼습니다. 앞으로 type은 이 파일에 정리하면 됩니다.
- `reducer.ts` 에서 불필요하게 생성했던 action creator 를 제거했습니다. 
-  Naming 변경
  - `actionCreatorAsync` -> `actionCreator`
  - `action` -> `actionRequest`

