### PR TITLE
MessageList threadStore에 저장하도록 변경 (#177)

### DIFF
--- a/client/src/api/message.ts
+++ b/client/src/api/message.ts
@@ -1,12 +1,16 @@
 import myAxios from '@util/myAxios'
-import { UpdateMessageRequestType } from '@type/message.type'
-import { MessageType } from '@type/thread.type'
+import {
+  UpdateMessageRequestType,
+  GetMessagesResponseType,
+} from '@type/message.type'
 
-const getMessages = async (threadId: number) => {
+const getMessages = async (
+  threadId: number,
+): Promise<GetMessagesResponseType> => {
   const response = await myAxios.get({
     path: `/message?threadId=${threadId}`,
   })
-  return response.data as { success: true; data: MessageType[] }
+  return response.data
 }
 
 const updateMessage = async (originalData: UpdateMessageRequestType) => {

--- a/client/src/component/molecule/Section/Section.tsx
+++ b/client/src/component/molecule/Section/Section.tsx
@@ -192,7 +192,7 @@ const Section = ({ title, type, channelList, workspaceId }: SectionProps) => {
               <M.ButtonDiv
                 buttonStyle={SectionModalContentStyle}
                 textStyle={SectionModalCententTextStyle}
-                onClick={handleCreateDMClick}
+                onClick={handleCreateDmClick}
               >
                 Create a DM
               </M.ButtonDiv>

--- a/client/src/component/organism/ChannelCard/ChannelCard.tsx
+++ b/client/src/component/organism/ChannelCard/ChannelCard.tsx
@@ -16,7 +16,7 @@ const ChannelCard = ({
   onLeaveButtonClick,
 }: ChannelCardProps) => {
   const { id, name, type, memberCount, joined } = channel
-  
+
   const [hover, setHover] = useState<boolean>(false)
 
   const handleMouseEnter = () => setHover(true)
@@ -86,7 +86,6 @@ const buttonStyle: ButtonType.StyleAttributes = {
   padding: '10px',
   width: '80px',
   height: '36px',
-  cursor: 'pointer',
 }
 const buttonTextStyle: TextType.StyleAttributes = {
   fontWeight: '500',

--- a/client/src/component/organism/MessageCard/MessageCard.tsx
+++ b/client/src/component/organism/MessageCard/MessageCard.tsx
@@ -19,7 +19,7 @@ interface MessageCardProps {
   data: GetThreadResponseType | MessageType
   type: 'THREAD' | 'MESSAGE'
   continuous?: boolean
-  onReplyButtonClick: () => void
+  onReplyButtonClick: (thread: GetThreadResponseType) => void
 }
 
 const MessageCard = ({
@@ -58,6 +58,8 @@ const MessageCard = ({
     // TODO: else -> message 일때
     setEditMode(false)
   }
+
+  const handleReplyButtonClick = () => onReplyButtonClick(thread)
 
   if (editMode) {
     return (
@@ -153,7 +155,7 @@ const MessageCard = ({
           <M.ReplyButton
             count={thread.replyCount}
             time={thread.lastReplyTime}
-            onClick={onReplyButtonClick}
+            onClick={handleReplyButtonClick}
           />
         </Styled.ContentWrapper>
 
@@ -166,7 +168,7 @@ const MessageCard = ({
               loginUserId={currentUser.id}
               onDeleteButtonClick={handleDeleteButtonClick}
               onEditButtonClick={handleEditButtonClick}
-              onReplyButtonClick={onReplyButtonClick}
+              onReplyButtonClick={handleReplyButtonClick}
             />
           )}
         </Styled.ActionBarWrapper>
@@ -208,7 +210,7 @@ const MessageCard = ({
           <M.ReplyButton
             count={thread.replyCount}
             time={thread.lastReplyTime}
-            onClick={onReplyButtonClick}
+            onClick={handleReplyButtonClick}
           />
         )}
       </Styled.ContentWrapper>
@@ -222,7 +224,7 @@ const MessageCard = ({
             loginUserId={currentUser.id}
             onDeleteButtonClick={handleDeleteButtonClick}
             onEditButtonClick={handleEditButtonClick}
-            onReplyButtonClick={onReplyButtonClick}
+            onReplyButtonClick={handleReplyButtonClick}
           />
         )}
       </Styled.ActionBarWrapper>

--- a/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
@@ -8,7 +8,7 @@ import { MessageType } from '@type/thread.type'
 import { ThreadDetailProps } from '.'
 import Styled from './ThreadDetail.style'
 
-const ThreadDetail = (props: ThreadDetailProps) => {
+const ThreadDetail = ({ onReplyButtonClick }: ThreadDetailProps) => {
   const { thread, messageList } = useSelector(
     (state: RootState) => state.threadStore.currentThread,
   )

--- a/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
@@ -1,33 +1,30 @@
 import React, { useEffect, useState } from 'react'
-import { toast } from 'react-toastify'
+import { useSelector } from 'react-redux'
+import { RootState } from '@store'
 import A from '@atom'
 import O from '@organism'
 import { TextType } from '@atom/Text'
-import MessageAPI from '@api/message'
 import { MessageType } from '@type/thread.type'
 import { ThreadDetailProps } from '.'
 import Styled from './ThreadDetail.style'
 
-const ThreadDetail = ({ thread }: ThreadDetailProps) => {
-  const { id, headMessage, replyCount } = thread
-  const [replyList, setReplyList] = useState<MessageType[]>([])
-
-  const getMessages = async () => {
-    const { success, data } = await MessageAPI.getMessages(id)
-    if (success) setReplyList(data)
-    else toast.error('Message를 가져오는데 실패했습니다.')
+const ThreadDetail = (props: ThreadDetailProps) => {
+  const { thread, messageList } = useSelector(
+    (state: RootState) => state.threadStore.currentThread,
+  )
+  let headMessage: MessageType | null = null
+  let replyCount: number = 0
+  if (thread) {
+    headMessage = thread.headMessage
+    replyCount = thread.replyCount
   }
-  useEffect(() => {
-    getMessages()
-  }, [id])
-
-  const firstMessage = headMessage
+  const replyList = messageList
 
   return (
     <Styled.ThreadContainer>
-      {firstMessage ? (
+      {headMessage ? (
         <O.MessageCard
-          data={firstMessage}
+          data={headMessage}
           type="MESSAGE"
           onReplyButtonClick={() => {}}
         />

--- a/client/src/component/organism/ThreadDetail/index.ts
+++ b/client/src/component/organism/ThreadDetail/index.ts
@@ -1,8 +1,5 @@
-import { GetThreadResponseType } from '@type/thread.type'
-
 export { default } from './ThreadDetail'
 
 export interface ThreadDetailProps {
-  thread: GetThreadResponseType
   onReplyButtonClick: () => void
 }

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '@store'
 import { getThreads, setCurrentThread } from '@store/reducer/thread.reducer'
+import { GetThreadResponseType } from '@type/thread.type'
 import A from '@atom'
 import O from '@organism'
 import myIcon from '@constant/icon'
@@ -9,7 +10,6 @@ import { IconType } from '@atom/Icon'
 import { TextType } from '@atom/Text'
 import { ThreadListProps } from '.'
 import Styled from './ThreadList.style'
-import { GetThreadResponseType } from '@type/thread.type'
 
 const ThreadList = ({
   channelInfo,

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '@store'
-import { getThreads } from '@store/reducer/thread.reducer'
+import { getThreads, setCurrentThread } from '@store/reducer/thread.reducer'
 import A from '@atom'
 import O from '@organism'
 import myIcon from '@constant/icon'
@@ -9,6 +9,7 @@ import { IconType } from '@atom/Icon'
 import { TextType } from '@atom/Text'
 import { ThreadListProps } from '.'
 import Styled from './ThreadList.style'
+import { GetThreadResponseType } from '@type/thread.type'
 
 const ThreadList = ({
   channelInfo,
@@ -58,6 +59,20 @@ const ThreadList = ({
     </Styled.ThreadSubViewHeaderWrapper>
   )
 
+  const threadDetail = (
+    <O.ThreadDetail
+      thread={threadList[0]}
+      onReplyButtonClick={() => alert(`reply button in thread `)}
+    />
+  )
+
+  const handleReplyButtonClick = (thread: GetThreadResponseType) => {
+    dispatch(setCurrentThread.request(thread))
+    handleSubViewOpen()
+    handleSubViewHeader(subViewHeader)
+    handleSubViewBody(threadDetail)
+  }
+
   return (
     <Styled.ChannelMainContainer>
       <Styled.ThreadListContainer ref={threadListEl} onScroll={handleScrollTop}>
@@ -93,19 +108,6 @@ const ThreadList = ({
         </Styled.ThreadListTop>
 
         {threads.map((thread, index, arr) => {
-          const threadDetail = (
-            <O.ThreadDetail
-              thread={thread}
-              onReplyButtonClick={() => alert(`reply to ${thread.id}`)}
-            />
-          )
-
-          const handleReplyButtonClick = () => {
-            handleSubViewOpen()
-            handleSubViewHeader(subViewHeader)
-            handleSubViewBody(threadDetail)
-          }
-
           const prevThread = index > 0 ? arr[index - 1] : undefined
 
           const sameUser = !!(

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -61,7 +61,6 @@ const ThreadList = ({
 
   const threadDetail = (
     <O.ThreadDetail
-      thread={threadList[0]}
       onReplyButtonClick={() => alert(`reply button in thread `)}
     />
   )

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -6,7 +6,7 @@ import O from '@organism'
 import styled from 'styled-components'
 import { RootState } from '@store'
 import { getChannels } from '@store/reducer/channel.reducer'
-import { deleteCurrentThread } from '@store/reducer/thread.reducer'
+import { clearCurrentThread } from '@store/reducer/thread.reducer'
 import { connectSocket } from '@store/reducer/socket.reducer'
 import { Channel, ChannelBrowser } from './template'
 
@@ -29,7 +29,7 @@ const WorkspacePage = () => {
   const handleSubViewOpen = () => setSubViewShow(true)
   const handleSubViewClose = () => {
     setSubViewShow(false)
-    dispatch(deleteCurrentThread())
+    dispatch(clearCurrentThread())
   }
   const handleSubViewHeader = (node: React.ReactNode) => setSubViewHeader(node)
   const handleSubViewBody = (node: React.ReactNode) => setSubViewBody(node)

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -6,6 +6,7 @@ import O from '@organism'
 import styled from 'styled-components'
 import { RootState } from '@store'
 import { getChannels } from '@store/reducer/channel.reducer'
+import { deleteCurrentThread } from '@store/reducer/thread.reducer'
 import { connectSocket } from '@store/reducer/socket.reducer'
 import { Channel, ChannelBrowser } from './template'
 
@@ -26,7 +27,10 @@ const WorkspacePage = () => {
   const [subViewBody, setSubViewBody] = useState<React.ReactNode>(<></>)
 
   const handleSubViewOpen = () => setSubViewShow(true)
-  const handleSubViewClose = () => setSubViewShow(false)
+  const handleSubViewClose = () => {
+    setSubViewShow(false)
+    dispatch(deleteCurrentThread())
+  }
   const handleSubViewHeader = (node: React.ReactNode) => setSubViewHeader(node)
   const handleSubViewBody = (node: React.ReactNode) => setSubViewBody(node)
 

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -42,7 +42,7 @@ export const RECEIVE_UPDATE_THREAD = 'thread/RECEIVE_UPDATE_THREAD' as const
 export const SET_CURRENT_THREAD_REQUEST = `thread/SET_CURRENT_THREAD_REQUEST` as const
 const SET_CURRENT_THREAD_SUCCESS = `thread/SET_CURRENT_THREAD_SUCCESS` as const
 const SET_CURRENT_THREAD_ERROR = `thread/SET_CURRENT_THREAD_ERROR` as const
-const DELETE_CURRENT_THREAD = `thread/DELETE_CURRENT_THREAD` as const
+const CLEAR_CURRENT_THREAD = `thread/CLEAR_CURRENT_THREAD` as const
 
 export const getThreads = createAsyncAction(
   GET_THREADS_REQUEST,
@@ -70,7 +70,7 @@ export const setCurrentThread = createAsyncAction(
   SET_CURRENT_THREAD_SUCCESS,
   SET_CURRENT_THREAD_ERROR,
 )<GetThreadResponseType, CurrentThreadType, AxiosError>()
-export const deleteCurrentThread = createAction(DELETE_CURRENT_THREAD)()
+export const clearCurrentThread = createAction(CLEAR_CURRENT_THREAD)()
 
 const actions = {
   getThreadsRequest: getThreads.request,
@@ -85,7 +85,7 @@ const actions = {
   setCurrentThreadRequest: setCurrentThread.request,
   setCurrentThreadSuccess: setCurrentThread.success,
   setCurrentThreadFailure: setCurrentThread.failure,
-  deleteCurrentThread,
+  clearCurrentThread,
 }
 
 export type ThreadAction = ActionType<typeof actions>
@@ -127,7 +127,7 @@ const reducer = createReducer<ThreadState, ThreadAction>(initialState, {
     loading: false,
     error: action.payload,
   }),
-  [DELETE_CURRENT_THREAD]: (state, _) => ({
+  [CLEAR_CURRENT_THREAD]: (state, _) => ({
     ...state,
     currentThread: {
       thread: null,

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -105,6 +105,25 @@ const reducer = createReducer<ThreadState, ThreadAction>(initialState, {
     loading: false,
     error: action.payload,
   }),
+  [SET_CURRENT_THREAD_REQUEST]: (state, _) => ({
+    ...state,
+    loading: true,
+    error: null,
+  }),
+  [SET_CURRENT_THREAD_SUCCESS]: (state, action) => ({
+    ...state,
+    loading: false,
+    error: null,
+    currentThread: {
+      thread: action.payload.thread,
+      messageList: action.payload.messageList,
+    },
+  }),
+  [SET_CURRENT_THREAD_ERROR]: (state, action) => ({
+    ...state,
+    loading: false,
+    error: action.payload,
+  }),
   [RECEIVE_CREATE_THREAD]: (state, action) => ({
     ...state,
     threadList: [...state.threadList, action.payload],

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -42,6 +42,7 @@ export const RECEIVE_UPDATE_THREAD = 'thread/RECEIVE_UPDATE_THREAD' as const
 export const SET_CURRENT_THREAD_REQUEST = `thread/SET_CURRENT_THREAD_REQUEST` as const
 const SET_CURRENT_THREAD_SUCCESS = `thread/SET_CURRENT_THREAD_SUCCESS` as const
 const SET_CURRENT_THREAD_ERROR = `thread/SET_CURRENT_THREAD_ERROR` as const
+const DELETE_CURRENT_THREAD = `thread/DELETE_CURRENT_THREAD` as const
 
 export const getThreads = createAsyncAction(
   GET_THREADS_REQUEST,
@@ -69,6 +70,7 @@ export const setCurrentThread = createAsyncAction(
   SET_CURRENT_THREAD_SUCCESS,
   SET_CURRENT_THREAD_ERROR,
 )<GetThreadResponseType, CurrentThreadType, AxiosError>()
+export const deleteCurrentThread = createAction(DELETE_CURRENT_THREAD)()
 
 const actions = {
   getThreadsRequest: getThreads.request,
@@ -83,6 +85,7 @@ const actions = {
   setCurrentThreadRequest: setCurrentThread.request,
   setCurrentThreadSuccess: setCurrentThread.success,
   setCurrentThreadFailure: setCurrentThread.failure,
+  deleteCurrentThread,
 }
 
 export type ThreadAction = ActionType<typeof actions>
@@ -123,6 +126,15 @@ const reducer = createReducer<ThreadState, ThreadAction>(initialState, {
     ...state,
     loading: false,
     error: action.payload,
+  }),
+  [DELETE_CURRENT_THREAD]: (state, _) => ({
+    ...state,
+    currentThread: {
+      thread: null,
+      messageList: [],
+    },
+    loading: false,
+    error: null,
   }),
   [RECEIVE_CREATE_THREAD]: (state, action) => ({
     ...state,

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -25,8 +25,6 @@ const initialState: ThreadState = {
   currentThread: {
     thread: null,
     messageList: [],
-    loading: true,
-    error: null,
   },
   loading: true,
   error: null,
@@ -41,6 +39,9 @@ export const DELETE_THREAD = 'thread/DELETE_THREAD' as const
 export const RECEIVE_DELETE_THREAD = 'thread/RECEIVE_DELETE_THREAD' as const
 export const UPDATE_THREAD = 'thread/UPDATE_THREAD' as const
 export const RECEIVE_UPDATE_THREAD = 'thread/RECEIVE_UPDATE_THREAD' as const
+export const SET_CURRENT_THREAD_REQUEST = `thread/SET_CURRENT_THREAD_REQUEST` as const
+const SET_CURRENT_THREAD_SUCCESS = `thread/SET_CURRENT_THREAD_SUCCESS` as const
+const SET_CURRENT_THREAD_ERROR = `thread/SET_CURRENT_THREAD_ERROR` as const
 
 export const getThreads = createAsyncAction(
   GET_THREADS_REQUEST,
@@ -63,6 +64,11 @@ export const updateThread = createAction(UPDATE_THREAD)<
 export const receiveUpdateThread = createAction(RECEIVE_UPDATE_THREAD)<
   GetThreadResponseType
 >()
+export const setCurrentThread = createAsyncAction(
+  SET_CURRENT_THREAD_REQUEST,
+  SET_CURRENT_THREAD_SUCCESS,
+  SET_CURRENT_THREAD_ERROR,
+)<GetThreadResponseType, CurrentThreadType, AxiosError>()
 
 const actions = {
   getThreadsRequest: getThreads.request,
@@ -74,6 +80,9 @@ const actions = {
   receiveDeleteThread,
   updateThread,
   receiveUpdateThread,
+  setCurrentThreadRequest: setCurrentThread.request,
+  setCurrentThreadSuccess: setCurrentThread.success,
+  setCurrentThreadFailure: setCurrentThread.failure,
 }
 
 export type ThreadAction = ActionType<typeof actions>

--- a/client/src/store/reducer/thread.reducer.ts
+++ b/client/src/store/reducer/thread.reducer.ts
@@ -9,17 +9,25 @@ import {
   GetThreadsRequestType,
   GetThreadResponseType,
   CreateThreadRequestType,
+  CurrentThreadType,
 } from '@type/thread.type'
 import { UpdateMessageRequestType } from '@type/message.type'
 
 interface ThreadState {
   threadList: GetThreadResponseType[]
+  currentThread: CurrentThreadType
   loading: boolean
   error: AxiosError | null
 }
 
 const initialState: ThreadState = {
   threadList: [],
+  currentThread: {
+    thread: null,
+    messageList: [],
+    loading: true,
+    error: null,
+  },
   loading: true,
   error: null,
 }

--- a/client/src/store/saga/thread.saga.ts
+++ b/client/src/store/saga/thread.saga.ts
@@ -116,17 +116,10 @@ function* setCurrentThreadSaga(
     )
 
     if (success) {
-      console.log(data)
-      // yield put(
-      //   sendSocketCreateThread({
-      //     channelId: +action.payload.channelId,
-      //     threadId: +data.threadId,
-      //   }),
-      // )
+      yield put(
+        setCurrentThread.success({ thread: action.payload, messageList: data }),
+      )
     }
-    yield put(
-      setCurrentThread.success({ thread: action.payload, messageList: data }),
-    )
   } catch (error) {
     yield put(setCurrentThread.failure(error))
   }

--- a/client/src/type/message.type.ts
+++ b/client/src/type/message.type.ts
@@ -1,6 +1,11 @@
-import { CreateThreadRequestType } from './thread.type'
+import { CreateThreadRequestType, MessageType } from './thread.type'
+import { ResponseType } from './response.type'
 
 export interface UpdateMessageRequestType extends CreateThreadRequestType {
   messageId: number
   threadId?: number
+}
+
+export interface GetMessagesResponseType extends ResponseType {
+  data: MessageType[]
 }

--- a/client/src/type/thread.type.ts
+++ b/client/src/type/thread.type.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios'
 import { UserType } from './user.type'
 
 interface FileType {
@@ -57,4 +58,11 @@ export interface CreateThreadRequestType {
   content: string
   channelId: number
   fileInfoList: { filePath: string; type: string }[] | null
+}
+
+export interface CurrentThreadType {
+  thread: GetThreadResponseType | null
+  messageList: MessageType[]
+  loading: boolean
+  error: AxiosError | null
 }

--- a/client/src/type/thread.type.ts
+++ b/client/src/type/thread.type.ts
@@ -63,6 +63,4 @@ export interface CreateThreadRequestType {
 export interface CurrentThreadType {
   thread: GetThreadResponseType | null
   messageList: MessageType[]
-  loading: boolean
-  error: AxiosError | null
 }


### PR DESCRIPTION
## Linked Issue
close #177

## 공유할 사항 
- `ThreadStore`에 `currentThread` 를 추가했습니다.
- `ThreadDetail`에 props로 넘어가던 `thread`를 `ThreadStore.currentThread.thread`에서 가져옵니다.
- BE에서 가져와서 렌더링해줬던 `messageList`를 `ThreadStore.currentThread.messageList`에서 가져옵니다.

