### PR TITLE
Member list modal fix, /user/channel/:channelId api 수정 (searchKeyword 추가)

### DIFF
--- a/client/src/api/channel.ts
+++ b/client/src/api/channel.ts
@@ -1,7 +1,6 @@
 import myAxios from '@util/myAxios'
-import { CreateChannelRequestType } from '@type/channel.type'
-
 import {
+  CreateChannelRequestType,
   ChannelRequestType,
   JoinChannelRequestType,
   JoinMembersToChannelRequestType,
@@ -51,5 +50,10 @@ const createNewChannel = async (data: CreateChannelRequestType) => {
   return response.data
 }
 
-export default { getChannels, joinChannel, joinMembersToChannel, getChannelInfo, createNewChannel }
-
+export default {
+  getChannels,
+  joinChannel,
+  joinMembersToChannel,
+  getChannelInfo,
+  createNewChannel,
+}

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,5 +1,10 @@
 import myAxios from '@util/myAxios'
 
+export interface SearchMembersRequestType {
+  channelId: number
+  searchKeyword: string
+}
+
 const getUserInfo = async () => {
   const response = await myAxios.get({ path: '/user/status' })
   return response.data
@@ -10,7 +15,20 @@ const getUsersByChannel = async ({ channelId }: { channelId: number }) => {
   return response.data
 }
 
+const searchMembers = async ({
+  channelId,
+  searchKeyword,
+}: SearchMembersRequestType) => {
+  const response = await myAxios.get({
+    path: `/user/channel/${channelId}${
+      searchKeyword ? `?searchKeyword=${searchKeyword}` : ''
+    }`,
+  })
+  return response.data
+}
+
 export default {
   getUserInfo,
   getUsersByChannel,
+  searchMembers,
 }

--- a/client/src/component/organism/MemberListModal/MemberListModal.style.ts
+++ b/client/src/component/organism/MemberListModal/MemberListModal.style.ts
@@ -22,11 +22,16 @@ const MemberListWrapper = styled.div`
 
 const MemberWrapper = styled.div`
   display: flex;
+  justify-content: space-between;
   align-items: center;
   padding: 10px 35px;
   &:hover {
     background-color: ${color.get('whiteHover')};
   }
+`
+const MemberLeftWrapper = styled.div`
+  display: flex;
+  align-items: center;
 `
 
 const EmptyListWrapper = styled.div`
@@ -41,5 +46,6 @@ export default {
   UpperWrapper,
   MemberListWrapper,
   MemberWrapper,
+  MemberLeftWrapper,
   EmptyListWrapper,
 }

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { RootState } from '@store'
 import A from '@atom'
 import M from '@molecule'
 import O from '@organism'
@@ -19,6 +21,9 @@ const MemberListModal = ({
   onClose,
 }: MemberListModalProps) => {
   const { id, type, name } = channel
+  const {
+    currentUser: { id: loginUserId },
+  } = useSelector((state: RootState) => state.userStore)
 
   const [inputKeyword, setInputKeyword] = useState('')
   const [memberSearchResult, setMemberSearchResult] = useState<UserType[]>([])
@@ -57,6 +62,10 @@ const MemberListModal = ({
 
   const handleClearSearchButtonClick = (): void => {
     setInputKeyword('')
+  }
+
+  const handleRemoveButtonClick = () => {
+    alert('remove')
   }
 
   return (
@@ -113,8 +122,22 @@ const MemberListModal = ({
           ) : (
             memberSearchResult.map((member) => (
               <Styled.MemberWrapper key={member.id}>
-                <O.Avatar user={member} size="BIG" clickable />
-                <A.Text customStyle={memberNameTextStyle}>{member.name}</A.Text>
+                <Styled.MemberLeftWrapper>
+                  <O.Avatar user={member} size="BIG" clickable />
+                  <A.Text customStyle={memberNameTextStyle}>
+                    {member.name + (loginUserId === member.id ? ' (you)' : '')}
+                  </A.Text>
+                </Styled.MemberLeftWrapper>
+
+                {type === 'PRIVATE' && loginUserId !== member.id && (
+                  <M.ButtonDiv
+                    onClick={handleRemoveButtonClick}
+                    buttonStyle={removeButtonStyle}
+                    textStyle={removeButtonTextStyle}
+                  >
+                    Remove
+                  </M.ButtonDiv>
+                )}
               </Styled.MemberWrapper>
             ))
           )}
@@ -165,8 +188,8 @@ const inputKeywordTextStyle: TextType.StyleAttributes = {
 }
 
 const memberNameTextStyle: TextType.StyleAttributes = {
-  fontWeight: '600',
-  fontSize: '1.4rem',
+  fontWeight: '700',
+  fontSize: '1.5rem',
   margin: '0 0 0 10px',
 }
 
@@ -181,6 +204,21 @@ const clearSearchButtonStyle: ButtonType.StyleAttributes = {
 const clearSearchButtonTextStyle: TextType.StyleAttributes = {
   fontSize: '1.4rem',
   fontWeight: '600',
+}
+
+const removeButtonStyle: ButtonType.StyleAttributes = {
+  cursor: 'pointer',
+  padding: '10px',
+  width: '80px',
+  height: '36px',
+  borderRadius: '4px',
+  border: `1px solid ${color.get('grey')}`,
+  backgroundColor: 'white',
+  hoverBackgroundColor: 'greyHover',
+}
+const removeButtonTextStyle: TextType.StyleAttributes = {
+  fontWeight: '600',
+  fontSize: '1.4rem',
 }
 
 export default MemberListModal

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -22,13 +22,17 @@ const MemberListModal = ({
 
   const [inputKeyword, setInputKeyword] = useState('')
   const [memberSearchResult, setMemberSearchResult] = useState<UserType[]>([])
+  const [memberTotalCount, setMemberTotalCount] = useState<number>(0)
 
   useEffect(() => {
     const getUsersByChannel = async () => {
       const { success, data } = await userAPI.getUsersByChannel({
         channelId: id,
       })
-      if (success) setMemberSearchResult(data)
+      if (success) {
+        setMemberSearchResult(data)
+        setMemberTotalCount(data.length)
+      }
     }
     getUsersByChannel()
   }, [])
@@ -66,7 +70,7 @@ const MemberListModal = ({
         <Styled.UpperWrapper>
           <A.Text customStyle={modalTitleTextStyle}>
             <>
-              {`${memberSearchResult.length} members in`}
+              {`${memberTotalCount} members in`}
               <A.Icon
                 icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock}
                 customStyle={{ margin: '0 3px 0 6px' }}
@@ -175,7 +179,7 @@ const clearSearchButtonStyle: ButtonType.StyleAttributes = {
 }
 
 const clearSearchButtonTextStyle: TextType.StyleAttributes = {
-  fontSize: '1.5rem',
+  fontSize: '1.4rem',
   fontWeight: '600',
 }
 

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -42,10 +42,7 @@ const MemberListModal = ({
     getUsersByChannel()
   }, [])
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const inputValue = e.target.value
-    setInputKeyword(inputValue)
-
+  useEffect(() => {
     const searchMembers = async (searchKeyword: string) => {
       const { success, data } = await userAPI.searchMembers({
         channelId: id,
@@ -57,7 +54,12 @@ const MemberListModal = ({
       }
       setMemberSearchResult([])
     }
-    searchMembers(inputValue)
+    searchMembers(inputKeyword)
+  }, [inputKeyword])
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const inputValue = e.target.value
+    setInputKeyword(inputValue)
   }
 
   const handleClearSearchButtonClick = (): void => {
@@ -183,7 +185,8 @@ const inputStyle: InputType.StyleAttributes = {
 }
 
 const inputKeywordTextStyle: TextType.StyleAttributes = {
-  fontWeight: 'bold',
+  fontWeight: '800',
+  fontSize: '1.5rem',
   margin: '0 0 0 5px',
 }
 

--- a/server/src/controller/user/user.controller.ts
+++ b/server/src/controller/user/user.controller.ts
@@ -35,6 +35,7 @@ const readUsersByChannel = async (
   try {
     const { code, json } = await userService.readUsersByChannel({
       channelId: +req.params.channelId,
+      searchKeyword: (req.query.searchKeyword as string) || '',
     })
     return res.status(code).json(json)
   } catch (error) {

--- a/server/src/service/user.service.ts
+++ b/server/src/service/user.service.ts
@@ -1,20 +1,26 @@
+import { Op } from 'sequelize'
 import UserModel from '@model/user.model'
 import ChannelModel from '@model/channel.model'
 // import UserChannelSection from '@model/userChannelSection.model'
 import { statusCode, resMessage } from '@util/constant'
 import validator from '@util/validator'
 
-type GoogleUser = {
+interface GoogleUser {
   sub: string
   email: string
   name: string
   picture: string
 }
 
-type UserInfo = {
+interface UserInfo {
   id: number
   email: string
   name: string
+}
+
+interface GetMembersRequestType {
+  channelId?: number
+  searchKeyword?: string
 }
 
 const findOrCreateUser = async ({ sub, email, name, picture }: GoogleUser) => {
@@ -48,7 +54,10 @@ const checkUser = async ({ id, email, name }: UserInfo): Promise<boolean> => {
   }
 }
 
-const readUsersByChannel = async ({ channelId }: { channelId: number }) => {
+const readUsersByChannel = async ({
+  channelId,
+  searchKeyword,
+}: GetMembersRequestType) => {
   if (!validator.isNumber(channelId))
     return {
       code: statusCode.BAD_REQUEST,
@@ -65,6 +74,20 @@ const readUsersByChannel = async ({ channelId }: { channelId: number }) => {
           attributes: [],
         },
       ],
+      where: {
+        [Op.or]: [
+          {
+            name: {
+              [Op.like]: `%${searchKeyword}%`,
+            },
+          },
+          {
+            email: {
+              [Op.like]: `%${searchKeyword}%`,
+            },
+          },
+        ],
+      },
       attributes: ['id', 'email', 'name', 'profileImageUrl'],
     })
 


### PR DESCRIPTION
## Linked Issue
close #161 

## 공유할 사항 
- getUsersByChannel api 변경 (searchKeyword 추가)
- MemberListModal 정상 작동하도록 수정
  - channel type === 'PRIVATE'인 경우 && login user가 아닌 경우에만 Remove 버튼 표시

<img width="532" alt="스크린샷 2020-12-09 오후 5 37 23" src="https://user-images.githubusercontent.com/57661699/101605393-7715bd80-3a45-11eb-9a8b-7a9e9a2b8502.png">

<img width="540" alt="스크린샷 2020-12-09 오후 5 37 01" src="https://user-images.githubusercontent.com/57661699/101605387-75e49080-3a45-11eb-88d8-988f81d2450c.png">
<img width="526" alt="스크린샷 2020-12-09 오후 5 37 09" src="https://user-images.githubusercontent.com/57661699/101605392-7715bd80-3a45-11eb-9a3e-08453d4543d4.png">


<img width="570" alt="스크린샷 2020-12-09 오후 5 36 50" src="https://user-images.githubusercontent.com/57661699/101605380-72e9a000-3a45-11eb-81a2-1c79d4d5d138.png">


## 논의할 사항 
- 
