### PR TITLE
channel member remove / leave channel 기능 구현

### DIFF
--- a/client/src/api/channel.ts
+++ b/client/src/api/channel.ts
@@ -4,6 +4,7 @@ import {
   ChannelRequestType,
   JoinChannelRequestType,
   JoinMembersToChannelRequestType,
+  DeleteMemberRequestType,
 } from '@type/channel.type'
 
 // TODO: workspace 전체의 채널을 어떻게 읽을 것인가
@@ -34,6 +35,13 @@ const joinMembersToChannel = async ({
   return response.data
 }
 
+const deleteMember = async ({ channelId, userId }: DeleteMemberRequestType) => {
+  const response = await myAxios.delete({
+    path: `/channel/${channelId}/user/${userId}`,
+  })
+  return response.data
+}
+
 const getChannelInfo = async (channelId: number) => {
   const response = await myAxios.get({
     path: `/channel/${channelId}`,
@@ -56,4 +64,5 @@ export default {
   joinMembersToChannel,
   getChannelInfo,
   createNewChannel,
+  deleteMember,
 }

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -122,7 +122,13 @@ const MemberListModal = ({
           ) : (
             memberSearchResult.map((member) => {
               const handleRemoveButtonClick = () => {
-                dispatch(deleteMember({ channelId: id, userId: member.id }))
+                dispatch(
+                  deleteMember({
+                    channelId: id,
+                    userId: member.id,
+                    onSuccess: onClose,
+                  }),
+                )
               }
               return (
                 <Styled.MemberWrapper key={member.id}>

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -122,9 +122,7 @@ const MemberListModal = ({
           ) : (
             memberSearchResult.map((member) => {
               const handleRemoveButtonClick = () => {
-                dispatch(
-                  deleteMember.request({ channelId: id, userId: member.id }),
-                )
+                dispatch(deleteMember({ channelId: id, userId: member.id }))
               }
               return (
                 <Styled.MemberWrapper key={member.id}>

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -11,6 +11,7 @@ import { ModalWrapperType } from '@atom/ModalWrapper'
 import myIcon from '@constant/icon'
 import color from '@constant/color'
 import { UserType } from '@type/user.type'
+import { deleteMember } from '@store/reducer/channel.reducer'
 import userAPI from '@api/user'
 import { MemberListModalProps } from '.'
 import Styled from './MemberListModal.style'
@@ -24,6 +25,7 @@ const MemberListModal = ({
   const {
     currentUser: { id: loginUserId },
   } = useSelector((state: RootState) => state.userStore)
+  const dispatch = useDispatch()
 
   const [inputKeyword, setInputKeyword] = useState('')
   const [memberSearchResult, setMemberSearchResult] = useState<UserType[]>([])
@@ -64,10 +66,6 @@ const MemberListModal = ({
 
   const handleClearSearchButtonClick = (): void => {
     setInputKeyword('')
-  }
-
-  const handleRemoveButtonClick = () => {
-    alert('remove')
   }
 
   return (
@@ -122,26 +120,34 @@ const MemberListModal = ({
               </M.ButtonDiv>
             </Styled.EmptyListWrapper>
           ) : (
-            memberSearchResult.map((member) => (
-              <Styled.MemberWrapper key={member.id}>
-                <Styled.MemberLeftWrapper>
-                  <O.Avatar user={member} size="BIG" clickable />
-                  <A.Text customStyle={memberNameTextStyle}>
-                    {member.name + (loginUserId === member.id ? ' (you)' : '')}
-                  </A.Text>
-                </Styled.MemberLeftWrapper>
+            memberSearchResult.map((member) => {
+              const handleRemoveButtonClick = () => {
+                dispatch(
+                  deleteMember.request({ channelId: id, userId: member.id }),
+                )
+              }
+              return (
+                <Styled.MemberWrapper key={member.id}>
+                  <Styled.MemberLeftWrapper>
+                    <O.Avatar user={member} size="BIG" clickable />
+                    <A.Text customStyle={memberNameTextStyle}>
+                      {member.name +
+                        (loginUserId === member.id ? ' (you)' : '')}
+                    </A.Text>
+                  </Styled.MemberLeftWrapper>
 
-                {type === 'PRIVATE' && loginUserId !== member.id && (
-                  <M.ButtonDiv
-                    onClick={handleRemoveButtonClick}
-                    buttonStyle={removeButtonStyle}
-                    textStyle={removeButtonTextStyle}
-                  >
-                    Remove
-                  </M.ButtonDiv>
-                )}
-              </Styled.MemberWrapper>
-            ))
+                  {type === 'PRIVATE' && loginUserId !== member.id && (
+                    <M.ButtonDiv
+                      onClick={handleRemoveButtonClick}
+                      buttonStyle={removeButtonStyle}
+                      textStyle={removeButtonTextStyle}
+                    >
+                      Remove
+                    </M.ButtonDiv>
+                  )}
+                </Styled.MemberWrapper>
+              )
+            })
           )}
         </Styled.MemberListWrapper>
       </Styled.Wrapper>

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -42,7 +42,7 @@ const WorkspacePage = () => {
   useEffect(() => {
     dispatch(getChannels.request({ workspaceId: +workspaceId }))
     dispatch(getCurrentWorkspaceInfo.request({ id: +workspaceId }))
-    dispatch(connectSocket.request({ workspaceId: +workspaceId }))
+    dispatch(connectSocket.request())
   }, [])
 
   return (

--- a/client/src/page/Workspace/template/ChannelBrowser.tsx
+++ b/client/src/page/Workspace/template/ChannelBrowser.tsx
@@ -23,7 +23,7 @@ const ChannelBrowser = ({ workspaceId }: ChannelBrowserPropsType) => {
       } = await myAxios.get({
         path: `/channel/all?workspaceId=${workspaceId}`,
       })
-      
+
       const filterdChannels = data.map((channel: ChannelCardType) => {
         return {
           ...channel,
@@ -47,12 +47,12 @@ const ChannelBrowser = ({ workspaceId }: ChannelBrowserPropsType) => {
     }
     getUserInChannels()
   }, [])
-  
+
   const handleJoinButtonClick = (channel: ChannelCardType) => () => {
     dispatch(joinChannel.request({ channel }))
     // TODO: ChannelBrowser 페이지 - channels의 해당 channel에 memberCount++
   }
-        
+
   const handleLeaveButtonClick = (channel: ChannelCardType) => () => {
     // channel 탈퇴 (saga async api 요청)
     // channel 탈퇴 성공 시 channelStore의 channelList에서 삭제

--- a/client/src/page/Workspace/template/ChannelBrowser.tsx
+++ b/client/src/page/Workspace/template/ChannelBrowser.tsx
@@ -4,7 +4,7 @@ import myAxios from '@util/myAxios'
 import styled from 'styled-components'
 import O from '@organism'
 import { RootState } from '@store'
-import { joinChannel } from '@store/reducer/channel.reducer'
+import { joinChannel, deleteMember } from '@store/reducer/channel.reducer'
 import { ChannelCardType } from '@type/channel.type'
 
 interface ChannelBrowserPropsType {
@@ -12,7 +12,12 @@ interface ChannelBrowserPropsType {
 }
 
 const ChannelBrowser = ({ workspaceId }: ChannelBrowserPropsType) => {
-  const { channelList } = useSelector((state: RootState) => state.channelStore)
+  const { channelList, loginUserId } = useSelector((state: RootState) => {
+    return {
+      channelList: state.channelStore.channelList,
+      loginUserId: state.userStore.currentUser.id,
+    }
+  })
   const [channels, setChannels] = useState<ChannelCardType[]>([])
   const dispatch = useDispatch()
 
@@ -54,10 +59,16 @@ const ChannelBrowser = ({ workspaceId }: ChannelBrowserPropsType) => {
   }
 
   const handleLeaveButtonClick = (channel: ChannelCardType) => () => {
-    // channel 탈퇴 (saga async api 요청)
-    // channel 탈퇴 성공 시 channelStore의 channelList에서 삭제
-    // & ChannelBrowser 페이지 - channels의 해당 channel에 memberCount--
-    alert(`${channel.id} leave!`)
+    // TODO: redirection 말고 channel browser의 data와 store의 channel list를 update 하는 방식 고려
+    dispatch(
+      deleteMember({
+        channelId: channel.id,
+        userId: loginUserId,
+        onSuccess: () => {
+          window.location.href = `/workspace/${workspaceId}/channel-browser`
+        },
+      }),
+    )
   }
 
   const channelBrowserMainViewHeader = (

--- a/client/src/page/WorkspaceBrowser/NewWorkspacePage.tsx
+++ b/client/src/page/WorkspaceBrowser/NewWorkspacePage.tsx
@@ -400,7 +400,7 @@ const WorkspaceImageStyle = {
   width: '15rem',
   height: '15rem',
   radius: '1rem',
-  cursor: false,
+  // cursor: false,
 }
 
 const slackImageStyle = {

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -13,6 +13,7 @@ import {
   CreateChannelRequestType,
   JoinChannelRequestType,
   JoinMembersToChannelRequestType,
+  DeleteMemberRequestType,
 } from '@type/channel.type'
 
 export interface ChannelState {
@@ -52,6 +53,10 @@ export const JOIN_MEMBERS_TO_CHANNEL_REQUEST = 'channel/JOIN_MEMBERS_TO_CHANNEL_
 const JOIN_MEMBERS_TO_CHANNEL_SUCCESS = 'channel/JOIN_MEMBERS_TO_CHANNEL_SUCCESS' as const
 const JOIN_MEMBERS_TO_CHANNEL_ERROR = 'channel/JOIN_MEMBERS_TO_CHANNEL_ERROR' as const
 
+export const DELETE_MEMBER_REQUEST = 'channel/DELETE_MEMBER_REQUEST' as const
+const DELETE_MEMBER_SUCCESS = 'channel/DELETE_MEMBER_SUCCESS' as const
+const DELETE_MEMBER_ERROR = 'channel/DELETE_MEMBER_ERROR' as const
+
 export const CREATE_CHANNEL_REQUEST = 'channel/CREATE_CHANNEL_REQUEST' as const
 const CREATE_CHANNEL_SUCCESS = 'channel/CREATE_CHANNEL_SUCCESS' as const
 const CREATE_CHANNEL_ERROR = 'channel/CREATE_CHANNEL_ERROR' as const
@@ -82,6 +87,12 @@ export const joinMembersToChannel = createAsyncAction(
   AxiosError
 >()
 
+export const deleteMember = createAsyncAction(
+  DELETE_MEMBER_REQUEST,
+  DELETE_MEMBER_SUCCESS,
+  DELETE_MEMBER_ERROR,
+)<DeleteMemberRequestType, CurrentChannelType, AxiosError>()
+
 export const createChannel = createAsyncAction(
   CREATE_CHANNEL_REQUEST,
   CREATE_CHANNEL_SUCCESS,
@@ -104,6 +115,9 @@ const actions = {
   joinMembersToChannelRequest: joinMembersToChannel.request,
   joinMembersToChannelSuccess: joinMembersToChannel.success,
   joinMembersToChannelError: joinMembersToChannel.failure,
+  deleteMemberRequest: deleteMember.request,
+  deleteMemberSuccess: deleteMember.success,
+  deleteMemberError: deleteMember.failure,
   createChannelRequest: createChannel.request,
   createChannelSuccess: createChannel.success,
   createChannelError: createChannel.failure,
@@ -178,6 +192,31 @@ const reducer = createReducer<ChannelState, ChannelAction>(initialState, {
     loading: false,
     error: action.payload,
   }),
+
+  [DELETE_MEMBER_REQUEST]: (state, _) => ({
+    ...state,
+    loading: true,
+    error: null,
+  }),
+  [DELETE_MEMBER_SUCCESS]: (state, action) => {
+    const { id } = action.payload
+    const sameChannel = id === state.currentChannel.id
+    const newCurrentChannel = sameChannel
+      ? action.payload
+      : state.currentChannel
+    return {
+      ...state,
+      loading: false,
+      currentChannel: { ...newCurrentChannel },
+      error: null,
+    }
+  },
+  [DELETE_MEMBER_ERROR]: (state, action) => ({
+    ...state,
+    loading: false,
+    error: action.payload,
+  }),
+
   [GET_CURRENT_CHANNEL_REQUEST]: (state, _) => ({
     ...state,
     loading: true,

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -53,9 +53,8 @@ export const JOIN_MEMBERS_TO_CHANNEL_REQUEST = 'channel/JOIN_MEMBERS_TO_CHANNEL_
 const JOIN_MEMBERS_TO_CHANNEL_SUCCESS = 'channel/JOIN_MEMBERS_TO_CHANNEL_SUCCESS' as const
 const JOIN_MEMBERS_TO_CHANNEL_ERROR = 'channel/JOIN_MEMBERS_TO_CHANNEL_ERROR' as const
 
-export const DELETE_MEMBER_REQUEST = 'channel/DELETE_MEMBER_REQUEST' as const
-const DELETE_MEMBER_SUCCESS = 'channel/DELETE_MEMBER_SUCCESS' as const
-const DELETE_MEMBER_ERROR = 'channel/DELETE_MEMBER_ERROR' as const
+export const DELETE_MEMBER = 'channel/DELETE_MEMBER' as const
+export const RECEIVE_DELETE_MEMBER = 'channel/RECEIVE_DELETE_MEMBER' as const
 
 export const CREATE_CHANNEL_REQUEST = 'channel/CREATE_CHANNEL_REQUEST' as const
 const CREATE_CHANNEL_SUCCESS = 'channel/CREATE_CHANNEL_SUCCESS' as const
@@ -87,11 +86,12 @@ export const joinMembersToChannel = createAsyncAction(
   AxiosError
 >()
 
-export const deleteMember = createAsyncAction(
-  DELETE_MEMBER_REQUEST,
-  DELETE_MEMBER_SUCCESS,
-  DELETE_MEMBER_ERROR,
-)<DeleteMemberRequestType, CurrentChannelType, AxiosError>()
+export const deleteMember = createAction(DELETE_MEMBER)<
+  DeleteMemberRequestType
+>()
+export const receiveDeleteMember = createAction(RECEIVE_DELETE_MEMBER)<
+  CurrentChannelType
+>()
 
 export const createChannel = createAsyncAction(
   CREATE_CHANNEL_REQUEST,
@@ -115,9 +115,8 @@ const actions = {
   joinMembersToChannelRequest: joinMembersToChannel.request,
   joinMembersToChannelSuccess: joinMembersToChannel.success,
   joinMembersToChannelError: joinMembersToChannel.failure,
-  deleteMemberRequest: deleteMember.request,
-  deleteMemberSuccess: deleteMember.success,
-  deleteMemberError: deleteMember.failure,
+  deleteMember,
+  receiveDeleteMember,
   createChannelRequest: createChannel.request,
   createChannelSuccess: createChannel.success,
   createChannelError: createChannel.failure,
@@ -193,29 +192,18 @@ const reducer = createReducer<ChannelState, ChannelAction>(initialState, {
     error: action.payload,
   }),
 
-  [DELETE_MEMBER_REQUEST]: (state, _) => ({
-    ...state,
-    loading: true,
-    error: null,
-  }),
-  [DELETE_MEMBER_SUCCESS]: (state, action) => {
+  [RECEIVE_DELETE_MEMBER]: (state, action) => {
     const { id } = action.payload
-    const sameChannel = id === state.currentChannel.id
-    const newCurrentChannel = sameChannel
-      ? action.payload
-      : state.currentChannel
+    if (state.currentChannel.id === id) {
+      return {
+        ...state,
+        currentChannel: { ...action.payload },
+      }
+    }
     return {
       ...state,
-      loading: false,
-      currentChannel: { ...newCurrentChannel },
-      error: null,
     }
   },
-  [DELETE_MEMBER_ERROR]: (state, action) => ({
-    ...state,
-    loading: false,
-    error: action.payload,
-  }),
 
   [GET_CURRENT_CHANNEL_REQUEST]: (state, _) => ({
     ...state,

--- a/client/src/store/reducer/channel.reducer.ts
+++ b/client/src/store/reducer/channel.reducer.ts
@@ -89,9 +89,10 @@ export const joinMembersToChannel = createAsyncAction(
 export const deleteMember = createAction(DELETE_MEMBER)<
   DeleteMemberRequestType
 >()
-export const receiveDeleteMember = createAction(RECEIVE_DELETE_MEMBER)<
-  CurrentChannelType
->()
+export const receiveDeleteMember = createAction(RECEIVE_DELETE_MEMBER)<{
+  channelInfo: CurrentChannelType
+  userId: number
+}>()
 
 export const createChannel = createAsyncAction(
   CREATE_CHANNEL_REQUEST,
@@ -193,11 +194,11 @@ const reducer = createReducer<ChannelState, ChannelAction>(initialState, {
   }),
 
   [RECEIVE_DELETE_MEMBER]: (state, action) => {
-    const { id } = action.payload
-    if (state.currentChannel.id === id) {
+    const { channelInfo } = action.payload
+    if (state.currentChannel.id === channelInfo.id) {
       return {
         ...state,
-        currentChannel: { ...action.payload },
+        currentChannel: { ...channelInfo },
       }
     }
     return {

--- a/client/src/store/reducer/socket.reducer.ts
+++ b/client/src/store/reducer/socket.reducer.ts
@@ -18,6 +18,7 @@ const CONNECT_SOCKET_REQUEST = 'socket/CONNECT_SOCKET_REQUEST' as const
 const CONNECT_SOCKET_SUCCESS = 'socket/CONNECT_SOCKET_SUCCESS' as const
 const CONNECT_SOCKET_ERROR = 'socket/CONNECT_SOCKET_ERROR' as const
 const SEND_SOCKET_JOIN_ROOM = 'socket/SEND_SOCKET_JOIN_ROOM' as const
+const SEND_SOCKET_DELETE_MEMBER = 'socket/SEND_SOCKET_DELETE_MEMBER' as const
 const SEND_SOCKET_CREATE_THREAD = 'socket/SECT_SOCKET_CREATE_THREAD' as const
 const SEND_SOCKET_DELETE_THREAD = 'socket/SEND_SOCKET_DELETE_THREAD' as const
 const SEND_SOCKET_UPDATE_THREAD = 'socket/SEND_SOCKET_UPDATE_THREAD' as const
@@ -29,6 +30,10 @@ export const connectSocket = createAsyncAction(
 )<undefined, Socket, Error>()
 export const sendSocketJoinRoom = createAction(SEND_SOCKET_JOIN_ROOM)<{
   channelIdList: number[]
+}>()
+export const sendSocketDeleteMember = createAction(SEND_SOCKET_DELETE_MEMBER)<{
+  channelId: number
+  userId: number
 }>()
 export const sendSocketCreateThread = createAction(SEND_SOCKET_CREATE_THREAD)<{
   channelId: number
@@ -48,6 +53,7 @@ const actions = {
   connectSocketSuccess: connectSocket.success,
   connectSocketFailure: connectSocket.failure,
   sendSocketJoinRoom,
+  sendSocketDeleteMember,
   sendSocketCreateThread,
   sendSocketDeleteThread,
   sendSocketUpdateThread,

--- a/client/src/store/saga/channel.saga.ts
+++ b/client/src/store/saga/channel.saga.ts
@@ -76,6 +76,7 @@ function* deleteMemberSaga(action: ReturnType<typeof deleteMember>) {
   try {
     const { success } = yield call(channelAPI.deleteMember, action.payload)
     if (success) {
+      action.payload.onSuccess!()
       yield put(
         sendSocketDeleteMember({
           channelId: +action.payload.channelId,

--- a/client/src/store/saga/channel.saga.ts
+++ b/client/src/store/saga/channel.saga.ts
@@ -103,15 +103,22 @@ function* receiveDeleteMemberSaga(
   action: ReturnType<typeof receiveDeleteMember>,
 ) {
   try {
-    const { loginUserId, workspaceId } = yield select((state) => {
-      return {
-        loginUserId: state.userStore.currentUser.id,
-        // TODO: workspaceId 교체
-        workspaceId: 1, // state.workspaceStore.currentWorkspace.id,
-      }
-    })
+    const { loginUserId, workspaceId, currentChannelId } = yield select(
+      (state) => {
+        return {
+          loginUserId: state.userStore.currentUser.id,
+          currentChannelId: state.channelStore.currentChannel.id,
+          // TODO: workspaceId 교체
+          workspaceId: 1, // state.workspaceStore.currentWorkspace.id,
+        }
+      },
+    )
+    // TODO: channel list update 필요
 
-    if (loginUserId === action.payload.userId) {
+    if (
+      loginUserId === action.payload.userId &&
+      currentChannelId === action.payload.channelInfo.id
+    ) {
       toast.success(
         `You have been removed from the private channel ${action.payload.channelInfo.name}`,
       )

--- a/client/src/store/saga/channel.saga.ts
+++ b/client/src/store/saga/channel.saga.ts
@@ -7,12 +7,14 @@ import {
   GET_CURRENT_CHANNEL_REQUEST,
   JOIN_CHANNEL_REQUEST,
   JOIN_MEMBERS_TO_CHANNEL_REQUEST,
+  DELETE_MEMBER_REQUEST,
   CREATE_CHANNEL_REQUEST,
   getChannels,
   getCurrentChannel,
   createChannel,
   joinChannel,
   joinMembersToChannel,
+  deleteMember,
 } from '../reducer/channel.reducer'
 
 function* getChannelsSaga(action: ReturnType<typeof getChannels.request>) {
@@ -69,6 +71,22 @@ function* joinMembersToChannelSaga(
   }
 }
 
+function* deleteMemberSaga(action: ReturnType<typeof deleteMember.request>) {
+  try {
+    const deleteResult = yield call(channelAPI.deleteMember, action.payload)
+    if (deleteResult.success) {
+      const { success, data } = yield call(
+        channelAPI.getChannelInfo,
+        action.payload.channelId,
+      )
+      if (success) yield put(deleteMember.success(data))
+    }
+  } catch (error) {
+    toast.error('Failed to delete member from channel')
+    yield put(deleteMember.failure(error))
+  }
+}
+
 function* createChannelSage(action: ReturnType<typeof createChannel.request>) {
   try {
     const { success, data } = yield call(
@@ -98,6 +116,10 @@ function* watchJoinChannelSaga() {
   yield takeLatest(JOIN_CHANNEL_REQUEST, joinChannelSaga)
 }
 
+function* watchDeleteMemberSaga() {
+  yield takeLatest(DELETE_MEMBER_REQUEST, deleteMemberSaga)
+}
+
 function* watchJoinMembersToChannelSaga() {
   yield takeLatest(JOIN_MEMBERS_TO_CHANNEL_REQUEST, joinMembersToChannelSaga)
 }
@@ -108,6 +130,7 @@ export default function* channelSaga() {
     fork(watchGetCurrentChannelSaga),
     fork(watchJoinChannelSaga),
     fork(watchJoinMembersToChannelSaga),
+    fork(watchDeleteMemberSaga),
     fork(watchCreateChannelSaga),
   ])
 }

--- a/client/src/store/saga/channel.saga.ts
+++ b/client/src/store/saga/channel.saga.ts
@@ -10,7 +10,10 @@ import {
 import { toast } from 'react-toastify'
 import channelAPI from '@api/channel'
 import { ChannelType } from '@type/channel.type'
-import { sendSocketDeleteMember } from '@store/reducer/socket.reducer'
+import {
+  sendSocketDeleteMember,
+  sendSocketJoinRoom,
+} from '@store/reducer/socket.reducer'
 import {
   GET_CHANNELS_REQUEST,
   GET_CURRENT_CHANNEL_REQUEST,
@@ -27,7 +30,6 @@ import {
   deleteMember,
   receiveDeleteMember,
 } from '../reducer/channel.reducer'
-import { sendSocketJoinRoom } from '../reducer/socket.reducer'
 
 function* getChannelsSaga(action: ReturnType<typeof getChannels.request>) {
   try {
@@ -109,8 +111,7 @@ function* receiveDeleteMemberSaga(
         return {
           loginUserId: state.userStore.currentUser.id,
           currentChannelId: state.channelStore.currentChannel.id,
-          // TODO: workspaceId 교체
-          workspaceId: 1, // state.workspaceStore.currentWorkspace.id,
+          workspaceId: state.workspaceStore.currentWorkspace.id,
         }
       },
     )

--- a/client/src/type/channel.type.ts
+++ b/client/src/type/channel.type.ts
@@ -39,6 +39,11 @@ export interface JoinMembersToChannelRequestType {
   userList: UserType[]
 }
 
+export interface DeleteMemberRequestType {
+  channelId: number
+  userId: number
+}
+
 export interface ChannelRequestType {
   workspaceId?: number
 }

--- a/client/src/type/channel.type.ts
+++ b/client/src/type/channel.type.ts
@@ -42,6 +42,7 @@ export interface JoinMembersToChannelRequestType {
 export interface DeleteMemberRequestType {
   channelId: number
   userId: number
+  onSuccess?: () => void
 }
 
 export interface ChannelRequestType {

--- a/server/src/controller/channel/channel.controller.ts
+++ b/server/src/controller/channel/channel.controller.ts
@@ -96,6 +96,22 @@ const joinMembersToChannel = async (
   }
 }
 
+const deleteMember = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { code, json } = await channelService.deleteMember({
+      channelId: +req.params.channelId,
+      userId: +req.params.userId,
+    })
+    return res.status(code).json(json)
+  } catch (error) {
+    return next(error)
+  }
+}
+
 export default {
   createChannel,
   readChannelsByUser,
@@ -103,4 +119,5 @@ export default {
   readChannelInfo,
   joinChannel,
   joinMembersToChannel,
+  deleteMember,
 }

--- a/server/src/controller/channel/index.ts
+++ b/server/src/controller/channel/index.ts
@@ -9,5 +9,6 @@ router.get('/all', channelController.readChannelsByWorkspace)
 router.get('/:channelId', channelController.readChannelInfo)
 router.post('/:channelId/join', channelController.joinChannel)
 router.post('/:channelId/join-members', channelController.joinMembersToChannel)
+router.delete('/:channelId/user/:userId', channelController.deleteMember)
 
 export default router

--- a/server/src/service/channel.service.ts
+++ b/server/src/service/channel.service.ts
@@ -4,7 +4,7 @@ import UserChannelSection from '@model/userChannelSection.model'
 import ThreadModel from '@model/thread.model'
 import MessageModel from '@model/message.model'
 import { statusCode, resMessage } from '@util/constant'
-import sequelize, { Op } from 'sequelize'
+import sequelize from 'sequelize'
 import sequelizeDB from '@model/sequelize'
 
 interface ChannelType {
@@ -347,6 +347,42 @@ const joinMembersToChannel = async ({
   }
 }
 
+const deleteMember = async ({
+  channelId,
+  userId,
+}: {
+  channelId: number
+  userId: number
+}) => {
+  if (
+    typeof channelId !== 'number' ||
+    channelId < 0 ||
+    typeof userId !== 'number' ||
+    userId < 0
+  )
+    return {
+      code: statusCode.BAD_REQUEST,
+      json: { success: false, message: resMessage.OUT_OF_VALUE },
+    }
+
+  try {
+    await UserChannelSection.destroy({
+      where: { ChannelId: channelId, UserId: userId },
+    })
+    return {
+      code: statusCode.OK,
+      json: {
+        success: true,
+      },
+    }
+  } catch (error) {
+    return {
+      code: statusCode.DB_ERROR,
+      json: { success: false, message: resMessage.DB_ERROR },
+    }
+  }
+}
+
 export default {
   createChannel,
   readChannelsByUser,
@@ -354,4 +390,5 @@ export default {
   readChannelInfo,
   joinChannel,
   joinMembersToChannel,
+  deleteMember,
 }

--- a/server/src/service/channel.service.ts
+++ b/server/src/service/channel.service.ts
@@ -368,6 +368,7 @@ const deleteMember = async ({
   try {
     await UserChannelSection.destroy({
       where: { ChannelId: channelId, UserId: userId },
+      force: true,
     })
     return {
       code: statusCode.OK,

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -36,7 +36,11 @@ namespace.on('connection', (socket: Socket) => {
       const { json } = await channelService.readChannelInfo({
         channelId,
       })
-      namespace.to(channelId.toString()).emit('DELETE_MEMBER', json.data)
+      const payload = {
+        channelInfo: json.data,
+        userId,
+      }
+      namespace.to(channelId.toString()).emit('DELETE_MEMBER', payload)
     },
   )
   socket.on(

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import { createServer } from 'http'
 import { Server, Socket } from 'socket.io'
 import threadService from '@service/thread.service'
+import channelService from '@service/channel.service'
 
 const server = createServer(express())
 
@@ -28,6 +29,16 @@ namespace.on('connection', (socket: Socket) => {
     socket.join(channelIdList.map((id) => id.toString()))
     console.log(socket.rooms)
   })
+  socket.on(
+    'DELETE_MEMBER',
+    async (data: { channelId: number; userId: number }) => {
+      const { channelId, userId } = data
+      const { json } = await channelService.readChannelInfo({
+        channelId,
+      })
+      namespace.to(channelId.toString()).emit('DELETE_MEMBER', json.data)
+    },
+  )
   socket.on(
     'CREATE_THREAD',
     async (data: { channelId: number; threadId: number }) => {


### PR DESCRIPTION
## Linked Issue
related #162

## 공유할 사항 
- ChannelHeader의 MemberListModal에서 Remove 버튼 클릭 시 member 강퇴시키기 가능 (private only)
  - 강퇴 당한 멤버는 해당 페이지에 있었다면 channel-browser page로 리다이렉션 & toast message display
  - 해당 페이지에 있었으나 강퇴당하지 않았다면 channel-header 정보만 업데이트

- Channel Browser page에서 Leave 버튼 클릭해 채널 탈퇴 가능
  -  channel-browser page 리렌더링

## 논의할 사항 
- Leave 시 channel browser redirection 말고 channel browser의 data와 store의 channel list를 update 하는 방식 고려.....해야할까
  - 그리하려면 channel browser 최근 데이터에 대한 store 관리가 필요할 듯
