### PR TITLE
Channel page의 Header 및 thread list top에서 DM 구분

### DIFF
--- a/client/src/component/organism/AddMemberModal/AddMemberModal.tsx
+++ b/client/src/component/organism/AddMemberModal/AddMemberModal.tsx
@@ -21,7 +21,7 @@ const AddMemberModal = ({ channel, onClose }: AddMemberModalProps) => {
     (state: RootState) => state.workspaceStore.currentWorkspace,
   )
   const dispatch = useDispatch()
-  const { id, type, name } = channel
+  const { id, type, name, memberCount } = channel
 
   const [members, setMembers] = useState<UserType[]>([])
 
@@ -88,13 +88,17 @@ const AddMemberModal = ({ channel, onClose }: AddMemberModalProps) => {
         <Styled.UpperWrapper>
           <A.Text customStyle={modalTitleTextStyle}>Add people</A.Text>
           <A.Text customStyle={channelNameTextStyle}>
-            <>
-              <A.Icon
-                icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock}
-                customStyle={{ margin: '0 3px 0 0' }}
-              />
-              {name}
-            </>
+            {type === 'DM' ? (
+              `${memberCount} members in this direct message room`
+            ) : (
+              <>
+                <A.Icon
+                  icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock}
+                  customStyle={{ margin: '0 3px 0 0' }}
+                />
+                {name}
+              </>
+            )}
           </A.Text>
         </Styled.UpperWrapper>
 

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.style.ts
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.style.ts
@@ -4,7 +4,6 @@ import color from '@constant/color'
 const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  // padding: 10px 20px;
   width: 100%;
   height: 100%;
 `
@@ -28,9 +27,22 @@ const MemberCountWrapper = styled.div`
   }
 `
 
+const DMMemberCountBox = styled.div`
+  border-radius: 4px;
+  background-color: ${color.get('darkGrey')};
+  color: white;
+  width: 14px;
+  height: 14px;
+  padding: 2px;
+  margin-right: 2px;
+  text-align: center;
+  font-weight: 600;
+`
+
 export default {
   Wrapper,
   LeftWrapper,
   RightWrapper,
   MemberCountWrapper,
+  DMMemberCountBox,
 }

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
@@ -5,21 +5,9 @@ import myIcon from '@constant/icon'
 import { ButtonType } from '@atom/Button'
 import { ImageType } from '@atom/Image'
 import { TextType } from '@atom/Text'
-import { UserType } from '@type/user.type'
+import getDMChannelTitle from '@util/getDMChannelTitle'
 import { ChannelHeaderProps } from '.'
-
 import Styled from './ChannelHeader.style'
-
-const getDMChannelTitle = (members: UserType[], memberCount: number) => {
-  const memberNameString = members.reduce((prev, cur, curIdx, arr) => {
-    const suffix = curIdx < arr.length - 1 ? ', ' : ''
-    return prev + cur.name + suffix
-  }, '')
-  const moreMembers = memberCount - members.length
-  return moreMembers > 0
-    ? `${memberNameString}... and ${moreMembers} more`
-    : memberNameString
-}
 
 const ChannelHeader = ({ channelInfo }: ChannelHeaderProps) => {
   const { name, type, memberCount, memberMax3 } = channelInfo

--- a/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
+++ b/client/src/component/organism/ChannelHeader/ChannelHeader.tsx
@@ -5,12 +5,26 @@ import myIcon from '@constant/icon'
 import { ButtonType } from '@atom/Button'
 import { ImageType } from '@atom/Image'
 import { TextType } from '@atom/Text'
+import { UserType } from '@type/user.type'
 import { ChannelHeaderProps } from '.'
 
 import Styled from './ChannelHeader.style'
 
+const getDMChannelTitle = (members: UserType[], memberCount: number) => {
+  const memberNameString = members.reduce((prev, cur, curIdx, arr) => {
+    const suffix = curIdx < arr.length - 1 ? ', ' : ''
+    return prev + cur.name + suffix
+  }, '')
+  const moreMembers = memberCount - members.length
+  return moreMembers > 0
+    ? `${memberNameString}... and ${moreMembers} more`
+    : memberNameString
+}
+
 const ChannelHeader = ({ channelInfo }: ChannelHeaderProps) => {
   const { name, type, memberCount, memberMax3 } = channelInfo
+  const headerTitle =
+    type !== 'DM' ? name : getDMChannelTitle(memberMax3, memberCount)
 
   const [memberListModalVisible, setMemberListModalVisible] = useState(false)
   const [addPeopleModalVisible, setAddPeopleModalVisible] = useState(false)
@@ -26,22 +40,15 @@ const ChannelHeader = ({ channelInfo }: ChannelHeaderProps) => {
   const handleAddPeopleButtonClick = () => setAddPeopleModalVisible(true)
   const handleAddPeopleModalClose = () => setAddPeopleModalVisible(false)
 
-  // const handleStarButtonClick = () => alert('channel - section')
-  const handleInfoButtonClick = () => alert('show detailed info')
-
   return (
     <Styled.Wrapper>
       <Styled.LeftWrapper>
-        <A.Icon icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock} />
-        <A.Text
-          customStyle={channelNameTextStyle}
-          onClick={handleInfoButtonClick}
-        >
-          {name}
-        </A.Text>
-        {/* <A.Button onClick={handleStarButtonClick} customStyle={buttonStyle}>
-          <A.Icon icon={myIcon.star} />
-        </A.Button> */}
+        {type === 'DM' ? (
+          <Styled.DMMemberCountBox>{memberCount}</Styled.DMMemberCountBox>
+        ) : (
+          <A.Icon icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock} />
+        )}
+        <A.Text customStyle={channelNameTextStyle}>{headerTitle}</A.Text>
       </Styled.LeftWrapper>
 
       <Styled.RightWrapper>
@@ -68,9 +75,9 @@ const ChannelHeader = ({ channelInfo }: ChannelHeaderProps) => {
         >
           <A.Icon icon={myIcon.addUser} />
         </A.Button>
-        <A.Button onClick={handleInfoButtonClick} customStyle={buttonStyle}>
+        {/* <A.Button onClick={handleInfoButtonClick} customStyle={buttonStyle}>
           <A.Icon icon={myIcon.info} />
-        </A.Button>
+        </A.Button> */}
       </Styled.RightWrapper>
 
       {memberListModalVisible && (
@@ -114,7 +121,7 @@ const channelNameTextStyle: TextType.StyleAttributes = {
   fontWeight: '800',
   fontSize: '1.6rem',
   cursor: 'pointer',
-  margin: '0 5px 0 3px',
+  margin: '0 5px 0 5px',
 }
 
 export default ChannelHeader

--- a/client/src/component/organism/MemberListModal/MemberListModal.tsx
+++ b/client/src/component/organism/MemberListModal/MemberListModal.tsx
@@ -80,11 +80,17 @@ const MemberListModal = ({
           <A.Text customStyle={modalTitleTextStyle}>
             <>
               {`${memberTotalCount} members in`}
-              <A.Icon
-                icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock}
-                customStyle={{ margin: '0 3px 0 6px' }}
-              />
-              {name}
+              {type === 'DM' ? (
+                ' this room'
+              ) : (
+                <>
+                  <A.Icon
+                    icon={type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock}
+                    customStyle={{ margin: '0 3px 0 6px' }}
+                  />
+                  {name}
+                </>
+              )}
             </>
           </A.Text>
 

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -20,6 +20,8 @@ const ThreadList = ({
   handleSubViewHeader,
   handleSubViewBody,
 }: ThreadListProps) => {
+  const { id, name, type, memberCount, memberMax3, createdAt } = channelInfo
+
   const threadEndRef = useRef<HTMLDivElement>(null)
   const threadListEl = useRef<HTMLDivElement>(null)
 
@@ -34,7 +36,6 @@ const ThreadList = ({
       threadEndRef.current!.scrollIntoView()
     }
   }
-
   useEffect(scrollToBottom, [threads[threads.length - 1]])
 
   const handleScrollTop = () => {
@@ -42,7 +43,7 @@ const ThreadList = ({
     if (scrollTop <= 150) {
       dispatch(
         getThreads.request({
-          channelId: +channelInfo.id,
+          channelId: +id,
           lastThreadId: threadList[0].id,
         }),
       )
@@ -51,16 +52,24 @@ const ThreadList = ({
 
   const channelIcon =
     // eslint-disable-next-line no-nested-ternary
-    channelInfo.type === 'DM'
+    type === 'DM'
       ? myIcon.message
-      : channelInfo.type === 'PUBLIC'
+      : type === 'PUBLIC'
       ? myIcon.hashtag
       : myIcon.lock
 
+  const channelDescription = createdAt
+    ? `This ${type === 'DM' ? 'room' : 'channel'} was created on ${new Date(
+        createdAt,
+      ).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })}.`
+    : ''
+
   const messageEditorPlaceHolder =
-    channelInfo.type === 'DM'
-      ? getDMChannelTitle(channelInfo.memberMax3, channelInfo.memberCount)
-      : `#${channelInfo.name}`
+    type === 'DM' ? getDMChannelTitle(memberMax3, memberCount) : `#${name}`
 
   const subViewHeader = (
     <Styled.ThreadSubViewHeaderWrapper>
@@ -69,9 +78,7 @@ const ThreadList = ({
       <Styled.ChannelNameWrapper>
         <A.Icon icon={channelIcon} customStyle={iconStyle} />
         <A.Text customStyle={subViewChannelNameTextStyle}>
-          {channelInfo.type === 'DM'
-            ? `Direct message with ${channelInfo.memberCount} others`
-            : channelInfo.name}
+          {type === 'DM' ? `Direct message with ${memberCount} others` : name}
         </A.Text>
       </Styled.ChannelNameWrapper>
     </Styled.ThreadSubViewHeaderWrapper>
@@ -96,7 +103,7 @@ const ThreadList = ({
 
           <Styled.ColumnFlexContainer>
             <A.Text customStyle={threadListTopTextStyle}>
-              {channelInfo.type === 'DM' ? (
+              {type === 'DM' ? (
                 'This is the very beginning of your group conversation'
               ) : (
                 <>
@@ -105,38 +112,24 @@ const ThreadList = ({
                     icon={channelIcon}
                     customStyle={{ ...threadListTopTextStyle, color: 'blue' }}
                   />
-                  <A.Text customStyle={channelNameTextStyle}>
-                    {channelInfo.name}
-                  </A.Text>
+                  <A.Text customStyle={channelNameTextStyle}>{name}</A.Text>
                   channel
                 </>
               )}
             </A.Text>
             <A.Text customStyle={channelDescTextStyle}>
-              {channelInfo.createdAt &&
-                `This ${
-                  channelInfo.type === 'DM' ? 'room' : 'channel'
-                } was created on ${new Date(
-                  channelInfo.createdAt,
-                ).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}.`}
+              {channelDescription}
             </A.Text>
           </Styled.ColumnFlexContainer>
         </Styled.ThreadListTop>
 
         {threads.map((thread, index, arr) => {
           const prevThread = index > 0 ? arr[index - 1] : undefined
-
           const sameUser = !!(
             prevThread && prevThread.User.id === thread.User.id
           )
           const hasReply = thread.replyCount !== 0
-
           const prevHasReply = prevThread && prevThread.replyCount !== 0
-
           const continuous = sameUser && !hasReply && !prevHasReply
           return (
             <O.MessageCard

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -49,7 +49,12 @@ const ThreadList = ({
   }
 
   const channelIcon =
-    channelInfo.type === 'PUBLIC' ? myIcon.hashtag : myIcon.lock
+    // eslint-disable-next-line no-nested-ternary
+    channelInfo.type === 'DM'
+      ? myIcon.message
+      : channelInfo.type === 'PUBLIC'
+      ? myIcon.hashtag
+      : myIcon.lock
 
   const subViewHeader = (
     <Styled.ThreadSubViewHeaderWrapper>
@@ -58,7 +63,9 @@ const ThreadList = ({
       <Styled.ChannelNameWrapper>
         <A.Icon icon={channelIcon} customStyle={iconStyle} />
         <A.Text customStyle={subViewChannelNameTextStyle}>
-          {channelInfo.name}
+          {channelInfo.type === 'DM'
+            ? `Direct message with ${channelInfo.memberCount} others`
+            : channelInfo.name}
         </A.Text>
       </Styled.ChannelNameWrapper>
     </Styled.ThreadSubViewHeaderWrapper>
@@ -80,23 +87,30 @@ const ThreadList = ({
           <Styled.ThreadTypeIconWrapper>
             <A.Icon icon={channelIcon} />
           </Styled.ThreadTypeIconWrapper>
+
           <Styled.ColumnFlexContainer>
             <A.Text customStyle={threadListTopTextStyle}>
-              <>
-                {'This is the very beginning of the '}
-                <A.Icon
-                  icon={channelIcon}
-                  customStyle={{ ...threadListTopTextStyle, color: 'blue' }}
-                />
-                <A.Text customStyle={channelNameTextStyle}>
-                  {channelInfo.name}
-                </A.Text>
-                channel
-              </>
+              {channelInfo.type === 'DM' ? (
+                'This is the very beginning of your group conversation'
+              ) : (
+                <>
+                  {'This is the very beginning of the '}
+                  <A.Icon
+                    icon={channelIcon}
+                    customStyle={{ ...threadListTopTextStyle, color: 'blue' }}
+                  />
+                  <A.Text customStyle={channelNameTextStyle}>
+                    {channelInfo.name}
+                  </A.Text>
+                  channel
+                </>
+              )}
             </A.Text>
             <A.Text customStyle={channelDescTextStyle}>
               {channelInfo.createdAt &&
-                `This channel was created on ${new Date(
+                `This ${
+                  channelInfo.type === 'DM' ? 'room' : 'channel'
+                } was created on ${new Date(
                   channelInfo.createdAt,
                 ).toLocaleDateString('en-US', {
                   year: 'numeric',

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -9,6 +9,7 @@ import O from '@organism'
 import myIcon from '@constant/icon'
 import { IconType } from '@atom/Icon'
 import { TextType } from '@atom/Text'
+import getDMChannelTitle from '@util/getDMChannelTitle'
 import { ThreadListProps } from '.'
 import Styled from './ThreadList.style'
 
@@ -55,6 +56,11 @@ const ThreadList = ({
       : channelInfo.type === 'PUBLIC'
       ? myIcon.hashtag
       : myIcon.lock
+
+  const messageEditorPlaceHolder =
+    channelInfo.type === 'DM'
+      ? getDMChannelTitle(channelInfo.memberMax3, channelInfo.memberCount)
+      : `#${channelInfo.name}`
 
   const subViewHeader = (
     <Styled.ThreadSubViewHeaderWrapper>
@@ -147,7 +153,7 @@ const ThreadList = ({
 
       <Styled.EditorContainer>
         <O.MessageEditor
-          placeHolder={`Send a message to #${channelInfo.name}`}
+          placeHolder={`Send a message to ${messageEditorPlaceHolder}`}
         />
       </Styled.EditorContainer>
     </Styled.ChannelMainContainer>

--- a/client/src/util/getDMChannelTitle.ts
+++ b/client/src/util/getDMChannelTitle.ts
@@ -1,0 +1,14 @@
+import { UserType } from '@type/user.type'
+
+const getDMChannelTitle = (members: UserType[], memberCount: number) => {
+  const memberNameString = members.reduce((prev, cur, curIdx, arr) => {
+    const suffix = curIdx < arr.length - 1 ? ', ' : ''
+    return prev + cur.name + suffix
+  }, '')
+  const moreMembers = memberCount - members.length
+  return moreMembers > 0
+    ? `${memberNameString}... and ${moreMembers} more`
+    : memberNameString
+}
+
+export default getDMChannelTitle


### PR DESCRIPTION
## Linked Issue
close #

## 공유할 사항 
- Channel page의 Header 및 thread list top에서 DM 구분
- AddMemberModal, MemberListModal에서도 DM 구분
<img width="1052" alt="스크린샷 2020-12-12 오후 4 47 14" src="https://user-images.githubusercontent.com/57661699/101978637-c2280e80-3c99-11eb-982a-e96b6101ebe4.png">
<img width="651" alt="스크린샷 2020-12-12 오후 4 47 25" src="https://user-images.githubusercontent.com/57661699/101978639-c48a6880-3c99-11eb-909d-8531bab44274.png">

## 논의할 사항 
- 
