### PR TITLE
People page 구현 (#204)

### DIFF
--- a/client/src/api/channel.ts
+++ b/client/src/api/channel.ts
@@ -12,7 +12,13 @@ const getChannels = async ({ workspaceId }: ChannelRequestType) => {
   const response = await myAxios.get({
     path: `/channel?workspaceId=${workspaceId}`,
   })
+  return response.data
+}
 
+const getAllChannels = async ({ workspaceId }: ChannelRequestType) => {
+  const response = await myAxios.get({
+    path: `/channel/all?workspaceId=${workspaceId}`,
+  })
   return response.data
 }
 
@@ -60,6 +66,7 @@ const createNewChannel = async (data: CreateChannelRequestType) => {
 
 export default {
   getChannels,
+  getAllChannels,
   joinChannel,
   joinMembersToChannel,
   getChannelInfo,

--- a/client/src/component/organism/ChannelBrowserHeader/ChannelBrowserHeader.style.ts
+++ b/client/src/component/organism/ChannelBrowserHeader/ChannelBrowserHeader.style.ts
@@ -4,7 +4,6 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  // padding: 10px 20px;
   width: 100%;
   height: 100%;
 `

--- a/client/src/component/organism/PeopleHeader/PeopleHeader.style.ts
+++ b/client/src/component/organism/PeopleHeader/PeopleHeader.style.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`
+
+export default {
+  Wrapper,
+}

--- a/client/src/component/organism/PeopleHeader/PeopleHeader.tsx
+++ b/client/src/component/organism/PeopleHeader/PeopleHeader.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import A from '@atom'
+import M from '@molecule'
+import color from '@constant/color'
+import { ButtonType } from '@atom/Button'
+import { TextType } from '@atom/Text'
+import { PeopleHeaderProps } from '.'
+
+import Styled from './PeopleHeader.style'
+
+const PeopleHeader = ({ workspaceId }: PeopleHeaderProps) => {
+  const [invitePeopleModalVisible, setInvitePeopleModalVisible] = useState(
+    false,
+  )
+
+  const handleInvitePeopleButtonClick = () => setInvitePeopleModalVisible(true)
+  const handleInvitePeopleModalClose = () => setInvitePeopleModalVisible(false)
+
+  // TODO: import 'Invite people to workspace modal'
+
+  return (
+    <Styled.Wrapper>
+      <A.Text customStyle={headerTextStyle}>People</A.Text>
+
+      <M.ButtonDiv
+        buttonStyle={invitePeopleButtonStyle}
+        textStyle={buttonTextStyle}
+        onClick={handleInvitePeopleButtonClick}
+      >
+        Invite people
+      </M.ButtonDiv>
+    </Styled.Wrapper>
+  )
+}
+
+const headerTextStyle: TextType.StyleAttributes = {
+  fontWeight: '800',
+  fontSize: '1.6rem',
+}
+
+const invitePeopleButtonStyle: ButtonType.StyleAttributes = {
+  border: `1px solid ${color.get('grey')}`,
+  hoverBackgroundColor: 'whiteHover',
+  padding: '10px',
+  height: '36px',
+}
+
+const buttonTextStyle: TextType.StyleAttributes = {
+  fontWeight: '500',
+  fontSize: '1.4rem',
+}
+
+export default PeopleHeader

--- a/client/src/component/organism/PeopleHeader/index.ts
+++ b/client/src/component/organism/PeopleHeader/index.ts
@@ -1,0 +1,5 @@
+export { default } from './PeopleHeader'
+
+export interface PeopleHeaderProps {
+  workspaceId: number
+}

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -22,6 +22,10 @@ const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
   const handleAllDmChannelClick = () => {
     history.push(`/workspace/${workspaceInfo.id}/all-dm`)
   }
+  const handlePeopleClick = () => {
+    history.push(`/workspace/${workspaceInfo.id}/people-browser`)
+  }
+
   return (
     <Styled.SideBarContainer>
       <Styled.WorkSpacePart>
@@ -88,6 +92,7 @@ const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
           <M.ButtonDiv
             buttonStyle={OtherChannelButtonStyle}
             textStyle={OtherChannelTextStyle}
+            onClick={handlePeopleClick}
           >
             <>
               <A.Icon

--- a/client/src/component/organism/TeammateCard/TeammateCard.style.ts
+++ b/client/src/component/organism/TeammateCard/TeammateCard.style.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: auto;
+  max-height: 330px;
+  min-height: 310px;
+  padding: 0;
+  background-color: white;
+  border: 1px solid lightgrey;
+  border-radius: 8px;
+  overflow: hidden;
+`
+
+const BottomWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 17px;
+`
+
+export default {
+  Wrapper,
+  BottomWrapper,
+}

--- a/client/src/component/organism/TeammateCard/TeammateCard.tsx
+++ b/client/src/component/organism/TeammateCard/TeammateCard.tsx
@@ -5,14 +5,16 @@ import { ImageType } from '@atom/Image'
 import { TeammateCardProps } from '.'
 import Styled from './TeammateCard.style'
 
-const TeammateCard = ({ user }: TeammateCardProps) => {
-  const { name, profileImageUrl } = user
+const TeammateCard = ({ user, loginUserId }: TeammateCardProps) => {
+  const { id, name, profileImageUrl } = user
 
   return (
     <Styled.Wrapper>
       <A.Image customStyle={profileImageStyle} url={profileImageUrl} />
       <Styled.BottomWrapper>
-        <A.Text customStyle={nameTextStyle}>{name}</A.Text>
+        <A.Text customStyle={nameTextStyle}>
+          {name + (loginUserId === id ? ' (you)' : '')}
+        </A.Text>
       </Styled.BottomWrapper>
     </Styled.Wrapper>
   )

--- a/client/src/component/organism/TeammateCard/TeammateCard.tsx
+++ b/client/src/component/organism/TeammateCard/TeammateCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import A from '@atom'
+import { TextType } from '@atom/Text'
+import { ImageType } from '@atom/Image'
+import { TeammateCardProps } from '.'
+import Styled from './TeammateCard.style'
+
+const TeammateCard = ({ user }: TeammateCardProps) => {
+  const { name, profileImageUrl } = user
+
+  return (
+    <Styled.Wrapper>
+      <A.Image customStyle={profileImageStyle} url={profileImageUrl} />
+      <Styled.BottomWrapper>
+        <A.Text customStyle={nameTextStyle}>{name}</A.Text>
+      </Styled.BottomWrapper>
+    </Styled.Wrapper>
+  )
+}
+
+const profileImageStyle: ImageType.StyleAttributes = {
+  width: '220px',
+  height: '220px',
+  radius: '0',
+}
+
+const nameTextStyle: TextType.StyleAttributes = {
+  fontSize: '1.7rem',
+  fontWeight: 'bold',
+  margin: '3px 0',
+}
+
+export default TeammateCard

--- a/client/src/component/organism/TeammateCard/index.ts
+++ b/client/src/component/organism/TeammateCard/index.ts
@@ -4,4 +4,5 @@ export { default } from './TeammateCard'
 
 export interface TeammateCardProps {
   user: UserType
+  loginUserId: number
 }

--- a/client/src/component/organism/TeammateCard/index.ts
+++ b/client/src/component/organism/TeammateCard/index.ts
@@ -1,0 +1,7 @@
+import { UserType } from '@type/user.type'
+
+export { default } from './TeammateCard'
+
+export interface TeammateCardProps {
+  user: UserType
+}

--- a/client/src/component/organism/TeammateList/TeammateList.style.ts
+++ b/client/src/component/organism/TeammateList/TeammateList.style.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components'
+
+const ResultListWrapper = styled.div`
+  flex: 1 1 0;
+  display: flex;
+  flex-wrap: wrap;
+  overflow-y: scroll;
+`
+const CardWrapper = styled.div`
+  margin: 0 12px 12px 0;
+  cursor: pointer;
+`
+
+const NoResultsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 22rem;
+`
+
+export default {
+  ResultListWrapper,
+  CardWrapper,
+  NoResultsWrapper,
+}

--- a/client/src/component/organism/TeammateList/TeammateList.tsx
+++ b/client/src/component/organism/TeammateList/TeammateList.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import A from '@atom'
+import O from '@organism'
+import { TextType } from '@atom/Text'
+import { TeammateListProps } from '.'
+
+import Styled from './TeammateList.style'
+
+const TeammateList = ({
+  teammateList,
+  onTeammateClick,
+  loginUserId,
+}: TeammateListProps) => {
+  return (
+    <Styled.ResultListWrapper>
+      {teammateList.length === 0 ? (
+        <Styled.NoResultsWrapper>
+          <A.Text customStyle={noResultsTextStyle}>No results</A.Text>
+          <A.Text customStyle={descTextStyle}>
+            You might want to try using different keywords,
+          </A.Text>
+          <A.Text customStyle={descTextStyle}>
+            checking for typos or adjusting your filters.
+          </A.Text>
+        </Styled.NoResultsWrapper>
+      ) : (
+        teammateList.map((teammate) => (
+          <Styled.CardWrapper onClick={onTeammateClick}>
+            <O.TeammateCard
+              user={teammate}
+              key={teammate.id}
+              loginUserId={loginUserId}
+            />
+          </Styled.CardWrapper>
+        ))
+      )}
+    </Styled.ResultListWrapper>
+  )
+}
+
+const noResultsTextStyle: TextType.StyleAttributes = {
+  fontSize: '2rem',
+  fontWeight: '800',
+  margin: '3px 0',
+}
+
+const descTextStyle: TextType.StyleAttributes = {
+  fontSize: '1.5rem',
+}
+
+export default TeammateList

--- a/client/src/component/organism/TeammateList/index.ts
+++ b/client/src/component/organism/TeammateList/index.ts
@@ -1,0 +1,9 @@
+import { UserType } from '@type/user.type'
+
+export { default } from './TeammateList'
+
+export interface TeammateListProps {
+  teammateList: UserType[]
+  onTeammateClick: () => void
+  loginUserId: number
+}

--- a/client/src/component/organism/index.ts
+++ b/client/src/component/organism/index.ts
@@ -19,6 +19,9 @@ import WorkspaceList from './WorkspaceList'
 import WorkspaceCard from './WorkspaceCard'
 import AddMemberModal from './AddMemberModal'
 import DmCard from './DmCard'
+import PeopleHeader from './PeopleHeader'
+import TeammateCard from './TeammateCard'
+import TeammateList from './TeammateList'
 
 export default {
   Header,
@@ -42,4 +45,7 @@ export default {
   WorkspaceCard,
   AddMemberModal,
   DmCard,
+  PeopleHeader,
+  TeammateCard,
+  TeammateList,
 }

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -10,7 +10,7 @@ import { getCurrentWorkspaceInfo } from '@store/reducer/workspace.reducer'
 import { getChannels } from '@store/reducer/channel.reducer'
 import { clearCurrentThread } from '@store/reducer/thread.reducer'
 import { connectSocket } from '@store/reducer/socket.reducer'
-import { Channel, ChannelBrowser, AllDms } from './template'
+import { Channel, ChannelBrowser, AllDms, People } from './template'
 
 interface MatchParamsType {
   workspaceId: string
@@ -62,11 +62,14 @@ const WorkspacePage = () => {
                   handleSubViewBody={handleSubViewBody}
                 />
               </Route>
+              <Route path={`/workspace/${workspaceId}/all-dm`}>
+                <AllDms workspaceId={+workspaceId} />
+              </Route>
               <Route path={`/workspace/${workspaceId}/channel-browser`}>
                 <ChannelBrowser workspaceId={+workspaceId} />
               </Route>
-              <Route path={`/workspace/${workspaceId}/all-dm`}>
-                <AllDms workspaceId={+workspaceId} />
+              <Route path={`/workspace/${workspaceId}/people-browser`}>
+                <People workspaceId={+workspaceId} />
               </Route>
             </MainView>
           </Switch>

--- a/client/src/page/Workspace/template/ChannelBrowser.tsx
+++ b/client/src/page/Workspace/template/ChannelBrowser.tsx
@@ -1,17 +1,18 @@
 import React, { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import myAxios from '@util/myAxios'
+import { RootState } from '@store'
 import styled from 'styled-components'
 import O from '@organism'
-import { RootState } from '@store'
-import { joinChannel, deleteMember } from '@store/reducer/channel.reducer'
 import { ChannelCardType } from '@type/channel.type'
+import channelAPI from '@api/channel'
+import { joinChannel, deleteMember } from '@store/reducer/channel.reducer'
 
 interface ChannelBrowserPropsType {
   workspaceId: number
 }
 
 const ChannelBrowser = ({ workspaceId }: ChannelBrowserPropsType) => {
+  const dispatch = useDispatch()
   const { channelList, loginUserId } = useSelector((state: RootState) => {
     return {
       channelList: state.channelStore.channelList,
@@ -19,16 +20,13 @@ const ChannelBrowser = ({ workspaceId }: ChannelBrowserPropsType) => {
     }
   })
   const [channels, setChannels] = useState<ChannelCardType[]>([])
-  const dispatch = useDispatch()
 
   useEffect(() => {
     const getWorkspaceChannels = async () => {
-      const {
-        data: { data },
-      } = await myAxios.get({
-        path: `/channel/all?workspaceId=${workspaceId}`,
+      const { success, data } = await channelAPI.getAllChannels({
+        workspaceId,
       })
-
+      // TODO: success 여부에 따른 처리
       const filterdChannels = data
         .map((channel: ChannelCardType) => {
           return {

--- a/client/src/page/Workspace/template/People.tsx
+++ b/client/src/page/Workspace/template/People.tsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from '@store'
+import styled from 'styled-components'
+import A from '@atom'
+import O from '@organism'
+import { InputType } from '@atom/Input'
+import { TextType } from '@atom/Text'
+import workspaceAPI from '@api/workspace'
+
+const People = ({ workspaceId }: { workspaceId: number }) => {
+  const { id: loginUserId } = useSelector(
+    (state: RootState) => state.userStore.currentUser,
+  )
+
+  const searchTeammates = async (searchKeyword: string) => {
+    const { success, data } = await workspaceAPI.getTeammates({
+      workspaceId,
+      searchKeyword,
+    })
+    if (success) setTeammates(data)
+  }
+
+  useEffect(() => {
+    searchTeammates('')
+  }, [])
+
+  const [teammates, setTeammates] = useState([])
+  const [inputKeyword, setInputKeyword] = useState('')
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const inputValue = e.target.value
+    setInputKeyword(inputValue)
+  }
+  const handleKeyPressOnInput = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (e.key === 'Enter') searchTeammates(inputKeyword)
+  }
+
+  const handleTeammateCardClick = () => {
+    alert('click')
+    // TODO: subview rendering
+  }
+
+  const peopleMainViewHeader = <O.PeopleHeader workspaceId={workspaceId} />
+  const peopleMainViewBody = (
+    <Wrapper>
+      <HeaderWrapper>
+        <A.Input
+          placeholder="Search by name or email"
+          value={inputKeyword}
+          onChange={handleInputChange}
+          customStyle={inputStyle}
+          onKeyPress={handleKeyPressOnInput}
+        />
+
+        <ResultListHeaderWrapper>
+          <A.Text customStyle={resultHeaderTextStyle}>
+            {teammates.length === 0
+              ? 'No results'
+              : teammates.length +
+                (teammates.length > 1 ? ' members' : ' member')}
+          </A.Text>
+        </ResultListHeaderWrapper>
+      </HeaderWrapper>
+
+      <O.TeammateList
+        teammateList={teammates}
+        onTeammateClick={handleTeammateCardClick}
+        loginUserId={loginUserId}
+      />
+    </Wrapper>
+  )
+
+  return (
+    <>
+      <ViewHeader>{peopleMainViewHeader}</ViewHeader>
+      <ViewBody>{peopleMainViewBody}</ViewBody>
+    </>
+  )
+}
+
+// TODO: 반복되는 ViewHeader 스타일 분리
+const ViewHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 61px;
+  flex: 0 0 61px;
+  padding: 10px 20px;
+  border-bottom: 1px solid rgb(230, 230, 230);
+  border-top: 1px solid rgb(230, 230, 230);
+`
+const ViewBody = styled.div`
+  flex: 1 1 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+`
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 16px;
+  height: 100%;
+`
+const HeaderWrapper = styled.div`
+  flex: 0 0 auto;
+  width: 100%;
+`
+const ResultListHeaderWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 13px 0;
+  //   border-bottom: 1px solid rgb(230, 230, 230);
+`
+
+const inputStyle: InputType.StyleAttributes = {
+  border: '1px solid grey',
+  borderRadius: '5px',
+  padding: '0 10px',
+  margin: '20px 0',
+  fontSize: '1.4rem',
+  width: '100%',
+}
+const resultHeaderTextStyle: TextType.StyleAttributes = {
+  color: 'darkGrey',
+  fontSize: '1.4rem',
+  fontWeight: '500',
+}
+
+export default People

--- a/client/src/page/Workspace/template/index.ts
+++ b/client/src/page/Workspace/template/index.ts
@@ -1,5 +1,6 @@
 import Channel from './Channel'
 import ChannelBrowser from './ChannelBrowser'
 import AllDms from './AllDms'
+import People from './People'
 
-export { Channel, ChannelBrowser, AllDms }
+export { Channel, ChannelBrowser, AllDms, People }


### PR DESCRIPTION
## Linked Issue
close #204

## 공유할 사항 
- TeammateCard, TeammateList 구현
- People page(template) 구현
  - name, email로 유저 검색 가능
<img width="1280" alt="스크린샷 2020-12-12 오후 4 50 44" src="https://user-images.githubusercontent.com/57661699/101978722-598d6180-3c9a-11eb-9bd2-3c197fcd635c.png">
<img width="1280" alt="스크린샷 2020-12-12 오후 4 50 52" src="https://user-images.githubusercontent.com/57661699/101978725-5e521580-3c9a-11eb-93d0-4a19e400b0a9.png">
<img width="1280" alt="스크린샷 2020-12-12 오후 4 50 59" src="https://user-images.githubusercontent.com/57661699/101978726-5eeaac00-3c9a-11eb-8bb6-a3a5f377a725.png">


## note
- TeammateCard 클릭 시 Subview 렌더링 구현 예정
- ChannelBrowser도 People page와 유사한 구조로 리팩토링하며 검색 기능 추가할 예정
