### PR TITLE
Channel page - join 되지 않은 public channel 접근 시 렌더링 변경

### DIFF
--- a/client/src/component/organism/ThreadDetail/ThreadDetail.style.ts
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.style.ts
@@ -28,6 +28,8 @@ const EditorContainer = styled.div`
   width: 100%;
   padding: 0 16px 20px 16px;
   background-color: white;
+`
+const JoinButtonContainer = styled.div`
   display: flex;
   justify-content: center;
 `
@@ -51,4 +53,5 @@ export default {
   ReplyListContainer,
   EditorContainer,
   NoContentWrapper,
+  JoinButtonContainer,
 }

--- a/client/src/component/organism/ThreadDetail/ThreadDetail.style.ts
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.style.ts
@@ -26,7 +26,7 @@ const ReplyListContainer = styled.div`
 const EditorContainer = styled.div`
   height: 110px;
   width: 100%;
-  padding: 0 16px 20px 16px;
+  padding: 0 16px 25px 16px;
   background-color: white;
 `
 const JoinButtonContainer = styled.div`

--- a/client/src/component/organism/ThreadDetail/ThreadDetail.style.ts
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.style.ts
@@ -28,6 +28,8 @@ const EditorContainer = styled.div`
   width: 100%;
   padding: 0 16px 20px 16px;
   background-color: white;
+  display: flex;
+  justify-content: center;
 `
 
 const NoContentWrapper = styled.div`

--- a/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
@@ -12,7 +12,10 @@ import { createMessage } from '@store/reducer/thread.reducer'
 import { ThreadDetailProps } from '.'
 import Styled from './ThreadDetail.style'
 
-const ThreadDetail = ({ channelId }: ThreadDetailProps) => {
+const ThreadDetail = ({
+  channelId,
+  onJoinChannelButtonClick,
+}: ThreadDetailProps) => {
   const { thread, messageList } = useSelector(
     (state: RootState) => state.threadStore.currentThread,
   )
@@ -79,12 +82,15 @@ const ThreadDetail = ({ channelId }: ThreadDetailProps) => {
             onSubmitButtonClick={handleSubmitButtonClick}
           />
         ) : (
-          <M.ButtonDiv
-            buttonStyle={joinButtonStyle}
-            textStyle={joinButtonTextStyle}
-          >
-            Join channel
-          </M.ButtonDiv>
+          <Styled.JoinButtonContainer>
+            <M.ButtonDiv
+              buttonStyle={joinButtonStyle}
+              textStyle={joinButtonTextStyle}
+              onClick={onJoinChannelButtonClick}
+            >
+              Join channel
+            </M.ButtonDiv>
+          </Styled.JoinButtonContainer>
         )}
       </Styled.EditorContainer>
     </Styled.ThreadContainer>

--- a/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
+++ b/client/src/component/organism/ThreadDetail/ThreadDetail.tsx
@@ -2,8 +2,11 @@ import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '@store'
 import A from '@atom'
+import M from '@molecule'
 import O from '@organism'
+import color from '@constant/color'
 import { TextType } from '@atom/Text'
+import { ButtonType } from '@atom/Button'
 import { MessageType, CreateMessageRequestType } from '@type/message.type'
 import { createMessage } from '@store/reducer/thread.reducer'
 import { ThreadDetailProps } from '.'
@@ -13,6 +16,9 @@ const ThreadDetail = ({ channelId }: ThreadDetailProps) => {
   const { thread, messageList } = useSelector(
     (state: RootState) => state.threadStore.currentThread,
   )
+  const { channelList } = useSelector((state: RootState) => state.channelStore)
+  const joined = channelList.find((channel) => channel.id === +channelId)
+
   let headMessage: MessageType | null = null
   let replyCount: number = 0
   let threadId: number = -1
@@ -65,12 +71,21 @@ const ThreadDetail = ({ channelId }: ThreadDetailProps) => {
       </Styled.ReplyListContainer>
 
       <Styled.EditorContainer>
-        <O.MessageEditor
-          placeHolder="Reply..."
-          type="MESSAGE"
-          id={thread?.id}
-          onSubmitButtonClick={handleSubmitButtonClick}
-        />
+        {joined ? (
+          <O.MessageEditor
+            placeHolder="Reply..."
+            type="MESSAGE"
+            id={thread?.id}
+            onSubmitButtonClick={handleSubmitButtonClick}
+          />
+        ) : (
+          <M.ButtonDiv
+            buttonStyle={joinButtonStyle}
+            textStyle={joinButtonTextStyle}
+          >
+            Join channel
+          </M.ButtonDiv>
+        )}
       </Styled.EditorContainer>
     </Styled.ThreadContainer>
   )
@@ -80,6 +95,21 @@ const replyCountTextStyle: TextType.StyleAttributes = {
   fontSize: '1.4rem',
   margin: '0 15px 0 0',
   color: 'darkGrey',
+}
+
+const joinButtonStyle: ButtonType.StyleAttributes = {
+  border: `1px solid ${color.get('green')}`,
+  backgroundColor: 'green',
+  hoverBackgroundColor: 'greenHover',
+  width: '125px',
+  height: '38px',
+  padding: '10px',
+  margin: '10px 0 0 0',
+}
+const joinButtonTextStyle: TextType.StyleAttributes = {
+  color: 'white',
+  fontWeight: '600',
+  fontSize: '1.5rem',
 }
 
 export default ThreadDetail

--- a/client/src/component/organism/ThreadDetail/index.ts
+++ b/client/src/component/organism/ThreadDetail/index.ts
@@ -2,4 +2,5 @@ export { default } from './ThreadDetail'
 
 export interface ThreadDetailProps {
   channelId: number
+  onJoinChannelButtonClick: () => void
 }

--- a/client/src/component/organism/ThreadList/ThreadList.style.ts
+++ b/client/src/component/organism/ThreadList/ThreadList.style.ts
@@ -20,6 +20,14 @@ const EditorContainer = styled.div`
   padding: 0 16px;
   background-color: white;
 `
+const GuideWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-top: 20px;
+  border-top: 1px solid lightgrey;
+`
 
 const ThreadSubViewHeaderWrapper = styled.div`
   display: flex;
@@ -61,6 +69,7 @@ export default {
   ChannelMainContainer,
   ThreadListContainer,
   EditorContainer,
+  GuideWrapper,
   ThreadSubViewHeaderWrapper,
   ChannelNameWrapper,
   ThreadListTop,

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -219,6 +219,7 @@ const joinButtonStyle: ButtonType.StyleAttributes = {
   backgroundColor: 'green',
   hoverBackgroundColor: 'greenHover',
   width: '125px',
+  height: '38px',
   padding: '10px',
   margin: '10px 0 0 0',
 }

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { useParams } from 'react-router-dom'
+import { useParams, useHistory } from 'react-router-dom'
 import { RootState } from '@store'
 import { getThreads, setCurrentThread } from '@store/reducer/thread.reducer'
 import { GetThreadResponseType } from '@type/thread.type'
@@ -12,6 +12,7 @@ import color from '@constant/color'
 import { IconType } from '@atom/Icon'
 import { TextType } from '@atom/Text'
 import { ButtonType } from '@atom/Button'
+import { joinChannel } from '@store/reducer/channel.reducer'
 import getDMChannelTitle from '@util/getDMChannelTitle'
 import { ThreadListProps } from '.'
 import Styled from './ThreadList.style'
@@ -31,7 +32,8 @@ const ThreadList = ({
   const dispatch = useDispatch()
   const { threadList } = useSelector((state: RootState) => state.threadStore)
   const { channelList } = useSelector((state: RootState) => state.channelStore)
-  const { channelId } = useParams<{
+  const { workspaceId, channelId } = useParams<{
+    workspaceId: string
     channelId: string
   }>()
   const joined = channelList.find((channel) => channel.id === +channelId)
@@ -76,6 +78,15 @@ const ThreadList = ({
   const messageEditorPlaceHolder =
     type === 'DM' ? getDMChannelTitle(memberMax3, memberCount) : `#${name}`
 
+  const handleJoinChannelButtonClick = () => {
+    dispatch(
+      joinChannel.request({
+        channel: channelInfo,
+        workspaceId: +workspaceId,
+      }),
+    )
+  }
+
   const subViewHeader = (
     <Styled.ThreadSubViewHeaderWrapper>
       <A.Text customStyle={threadTextStyle}>Thread</A.Text>
@@ -89,7 +100,12 @@ const ThreadList = ({
     </Styled.ThreadSubViewHeaderWrapper>
   )
 
-  const threadDetail = <O.ThreadDetail channelId={+channelId} />
+  const threadDetail = (
+    <O.ThreadDetail
+      channelId={+channelId}
+      onJoinChannelButtonClick={handleJoinChannelButtonClick}
+    />
+  )
 
   const handleReplyButtonClick = (thread: GetThreadResponseType) => {
     dispatch(setCurrentThread.request(thread))
@@ -164,6 +180,7 @@ const ThreadList = ({
             <M.ButtonDiv
               buttonStyle={joinButtonStyle}
               textStyle={joinButtonTextStyle}
+              onClick={handleJoinChannelButtonClick}
             >
               Join channel
             </M.ButtonDiv>

--- a/client/src/component/organism/ThreadList/ThreadList.tsx
+++ b/client/src/component/organism/ThreadList/ThreadList.tsx
@@ -5,10 +5,13 @@ import { RootState } from '@store'
 import { getThreads, setCurrentThread } from '@store/reducer/thread.reducer'
 import { GetThreadResponseType } from '@type/thread.type'
 import A from '@atom'
+import M from '@molecule'
 import O from '@organism'
 import myIcon from '@constant/icon'
+import color from '@constant/color'
 import { IconType } from '@atom/Icon'
 import { TextType } from '@atom/Text'
+import { ButtonType } from '@atom/Button'
 import getDMChannelTitle from '@util/getDMChannelTitle'
 import { ThreadListProps } from '.'
 import Styled from './ThreadList.style'
@@ -27,9 +30,11 @@ const ThreadList = ({
 
   const dispatch = useDispatch()
   const { threadList } = useSelector((state: RootState) => state.threadStore)
+  const { channelList } = useSelector((state: RootState) => state.channelStore)
   const { channelId } = useParams<{
     channelId: string
   }>()
+  const joined = channelList.find((channel) => channel.id === +channelId)
 
   const scrollToBottom = () => {
     if (threadEndRef) {
@@ -145,9 +150,25 @@ const ThreadList = ({
       </Styled.ThreadListContainer>
 
       <Styled.EditorContainer>
-        <O.MessageEditor
-          placeHolder={`Send a message to ${messageEditorPlaceHolder}`}
-        />
+        {joined ? (
+          <O.MessageEditor
+            placeHolder={`Send a message to ${messageEditorPlaceHolder}`}
+          />
+        ) : (
+          <Styled.GuideWrapper>
+            <div>
+              <A.Text customStyle={guideTextStyle}>You are viewing</A.Text>
+              <A.Text customStyle={guideChannelTextStyle}>{` #${name}`}</A.Text>
+            </div>
+
+            <M.ButtonDiv
+              buttonStyle={joinButtonStyle}
+              textStyle={joinButtonTextStyle}
+            >
+              Join channel
+            </M.ButtonDiv>
+          </Styled.GuideWrapper>
+        )}
       </Styled.EditorContainer>
     </Styled.ChannelMainContainer>
   )
@@ -184,6 +205,27 @@ const channelNameTextStyle: TextType.StyleAttributes = {
 const channelDescTextStyle: TextType.StyleAttributes = {
   fontSize: '1.5rem',
   color: 'darkGrey',
+}
+
+const guideTextStyle: TextType.StyleAttributes = {
+  fontSize: '1.8rem',
+}
+const guideChannelTextStyle: TextType.StyleAttributes = {
+  fontSize: '1.8rem',
+  fontWeight: '700',
+}
+const joinButtonStyle: ButtonType.StyleAttributes = {
+  border: `1px solid ${color.get('green')}`,
+  backgroundColor: 'green',
+  hoverBackgroundColor: 'greenHover',
+  width: '125px',
+  padding: '10px',
+  margin: '10px 0 0 0',
+}
+const joinButtonTextStyle: TextType.StyleAttributes = {
+  color: 'white',
+  fontWeight: '600',
+  fontSize: '1.5rem',
 }
 
 export default ThreadList

--- a/client/src/type/channel.type.ts
+++ b/client/src/type/channel.type.ts
@@ -31,7 +31,7 @@ export interface CreateChannelRequestType {
 }
 
 export interface JoinChannelRequestType {
-  channel: ChannelCardType
+  channel: ChannelCardType | ChannelType
   userId?: number
   workspaceId: number
   onSuccess?: () => void


### PR DESCRIPTION
## Linked Issue
close #230 

## 공유할 사항 
- join 되어있지 않은 public 채널 접근 시 MessageEditor 자리에 Join channel 버튼 생성
- Thread detail(subview)의 message editor도 동일하게 렌더링

<img width="1037" alt="스크린샷 2020-12-15 오전 5 27 09" src="https://user-images.githubusercontent.com/57661699/102132020-6c6c8580-3e96-11eb-8c5b-56c0f237daa5.png">


## 논의할 사항 
- BE 로직에서도 접근 권한 체크해주어야 할 것 같습니다.
