### PR TITLE
Sidebar - workspace list 추가

### DIFF
--- a/client/src/component/organism/SideBar/SideBar.style.ts
+++ b/client/src/component/organism/SideBar/SideBar.style.ts
@@ -17,6 +17,9 @@ const SideBarContainer = styled.div`
 const WorkSpacePart = styled.div`
   border-bottom: 1px solid rgb(230, 230, 230);
   height: 60px;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
 `
 
 const OtherPagePart = styled.div`
@@ -31,21 +34,11 @@ const SectionChannelPart = styled.div`
   display: flex;
   flex-direction: column;
 `
-const DirectMessagePart = styled.div``
-
-const WorkspaceTitleWrapper = styled.div`
-  width: 20rem;
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-`
 
 export default {
-  WorkspaceTitleWrapper,
   SideBarContainer,
   WorkSpacePart,
   OtherPagePart,
   SectionChannelPart,
   ScrollContainer,
-  DirectMessagePart,
 }

--- a/client/src/component/organism/SideBar/SideBar.tsx
+++ b/client/src/component/organism/SideBar/SideBar.tsx
@@ -29,24 +29,7 @@ const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
   return (
     <Styled.SideBarContainer>
       <Styled.WorkSpacePart>
-        <M.ButtonDiv
-          buttonStyle={WorkSpaceButtonStyle}
-          textStyle={WorkSpaceTextStyle}
-        >
-          <Styled.WorkspaceTitleWrapper>
-            <A.Image
-              url={workspaceInfo.imageUrl}
-              customStyle={{
-                height: '4.5rem',
-                width: '4.5rem',
-                radius: '4px',
-              }}
-            />
-            <A.Text customStyle={WorkSpaceTextStyle}>
-              {workspaceInfo.name}
-            </A.Text>
-          </Styled.WorkspaceTitleWrapper>
-        </M.ButtonDiv>
+        <A.Text customStyle={WorkSpaceTextStyle}>{workspaceInfo.name}</A.Text>
       </Styled.WorkSpacePart>
       <Styled.ScrollContainer>
         <Styled.OtherPagePart>
@@ -110,13 +93,6 @@ const SideBar = ({ workspaceInfo, channelList }: SideBarProps) => {
   )
 }
 
-const WorkSpaceButtonStyle = {
-  width: '100%',
-  height: '100%',
-  display: 'flex',
-  justifyContent: 'center',
-}
-
 const OtherChannelButtonStyle = {
   width: '100%',
   height: '100%',
@@ -140,12 +116,6 @@ const OtherChannelIconStyle = {
 const WorkSpaceTextStyle = {
   fontSize: '16px',
   fontWeight: 'bold',
-}
-
-const WorkSpaceIconStyle = {
-  color: 'black',
-  fontSize: '16px',
-  margin: '0px 0px 0px 20px',
 }
 
 export default SideBar

--- a/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.style.ts
+++ b/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.style.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: auto;
+  border-right: 1px solid rgb(230, 230, 230);
+  overflow-y: scroll;
+`
+
+const ImageWrapper = styled.div`
+  margin-top: 10px;
+  border: 3px solid transparent;
+  border-radius: 12px;
+  padding: 2px;
+  transition: all ease 0.5s 0s;
+  &:hover {
+    border: 3px solid #eef3f3;
+    transition: all ease 0.5s 0s;
+  }
+`
+
+const CurrentWorkspaceImageWrapper = styled.div`
+  margin-top: 10px;
+  border: 3px solid #cbd7d8;
+  border-radius: 12px;
+  padding: 2px;
+`
+
+export default {
+  Wrapper,
+  ImageWrapper,
+  CurrentWorkspaceImageWrapper,
+}

--- a/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
+++ b/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import A from '@atom'
+import { ImageType } from '@atom/Image'
+import { WorkspaceSideBarProps } from '.'
+import Styled from './WorkspaceSideBar.style'
+
+const WorkspaceSideBar = ({
+  workspaceList,
+  currentWorkspaceId,
+}: WorkspaceSideBarProps) => {
+  const handleWorkspaceClick = (workspaceId: number) => () => {
+    window.location.href = `/workspace/${workspaceId}/channel-browser`
+  }
+
+  return (
+    <Styled.Wrapper>
+      {workspaceList.map((workspace) => {
+        return workspace.id === currentWorkspaceId ? (
+          <Styled.CurrentWorkspaceImageWrapper>
+            <A.Image url={workspace.imageUrl} customStyle={workspaceImgStyle} />
+          </Styled.CurrentWorkspaceImageWrapper>
+        ) : (
+          <Styled.ImageWrapper>
+            <A.Image
+              url={workspace.imageUrl}
+              customStyle={workspaceImgStyle}
+              onClick={handleWorkspaceClick(workspace.id)}
+            />
+          </Styled.ImageWrapper>
+        )
+      })}
+    </Styled.Wrapper>
+  )
+}
+
+const workspaceImgStyle: ImageType.StyleAttributes = {
+  width: '37px',
+  radius: '8px',
+}
+
+export default WorkspaceSideBar

--- a/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
+++ b/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useHistory } from 'react-router-dom'
 import A from '@atom'
 import { ImageType } from '@atom/Image'
 import { ButtonType } from '@atom/Button'
@@ -10,11 +11,13 @@ const WorkspaceSideBar = ({
   workspaceList,
   currentWorkspaceId,
 }: WorkspaceSideBarProps) => {
+  const history = useHistory()
+
   const handleWorkspaceClick = (workspaceId: number) => () => {
     window.location.href = `/workspace/${workspaceId}/channel-browser`
   }
   const handleAddWorkspaceButtonClick = () => {
-    alert('add workspace')
+    history.push('/workspace/new')
   }
 
   return (

--- a/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
+++ b/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import A from '@atom'
 import { ImageType } from '@atom/Image'
+import { ButtonType } from '@atom/Button'
+import myIcon from '@constant/icon'
 import { WorkspaceSideBarProps } from '.'
 import Styled from './WorkspaceSideBar.style'
 
@@ -10,6 +12,9 @@ const WorkspaceSideBar = ({
 }: WorkspaceSideBarProps) => {
   const handleWorkspaceClick = (workspaceId: number) => () => {
     window.location.href = `/workspace/${workspaceId}/channel-browser`
+  }
+  const handleAddWorkspaceButtonClick = () => {
+    alert('add workspace')
   }
 
   return (
@@ -29,6 +34,12 @@ const WorkspaceSideBar = ({
           </Styled.ImageWrapper>
         )
       })}
+      <A.Button
+        customStyle={plusButtonStyle}
+        onClick={handleAddWorkspaceButtonClick}
+      >
+        <A.Icon icon={myIcon.plus} />
+      </A.Button>
     </Styled.Wrapper>
   )
 }
@@ -36,6 +47,14 @@ const WorkspaceSideBar = ({
 const workspaceImgStyle: ImageType.StyleAttributes = {
   width: '37px',
   radius: '8px',
+}
+const plusButtonStyle: ButtonType.StyleAttributes = {
+  hoverBackgroundColor: 'greyHover',
+  width: '37px',
+  height: '37px',
+  borderRadius: '8px',
+  padding: '2px',
+  margin: '10px 0',
 }
 
 export default WorkspaceSideBar

--- a/client/src/component/organism/WorkspaceSideBar/index.ts
+++ b/client/src/component/organism/WorkspaceSideBar/index.ts
@@ -1,0 +1,8 @@
+import { WorkspaceResponseType } from '@type/workspace.type'
+
+export { default } from './WorkspaceSideBar'
+
+export interface WorkspaceSideBarProps {
+  workspaceList: WorkspaceResponseType[]
+  currentWorkspaceId: number
+}

--- a/client/src/component/organism/index.ts
+++ b/client/src/component/organism/index.ts
@@ -23,6 +23,7 @@ import PeopleHeader from './PeopleHeader'
 import TeammateCard from './TeammateCard'
 import TeammateList from './TeammateList'
 import UserDetail from './UserDetail'
+import WorkspaceSideBar from './WorkspaceSideBar'
 
 export default {
   Header,
@@ -50,4 +51,5 @@ export default {
   TeammateCard,
   TeammateList,
   UserDetail,
+  WorkspaceSideBar,
 }

--- a/client/src/page/Workspace/WorkspacePage.tsx
+++ b/client/src/page/Workspace/WorkspacePage.tsx
@@ -5,7 +5,10 @@ import M from '@molecule'
 import O from '@organism'
 import styled from 'styled-components'
 import { RootState } from '@store'
-import { getCurrentWorkspaceInfo } from '@store/reducer/workspace.reducer'
+import {
+  getWorkspace,
+  getCurrentWorkspaceInfo,
+} from '@store/reducer/workspace.reducer'
 import { clearCurrentThread } from '@store/reducer/thread.reducer'
 import { connectSocket } from '@store/reducer/socket.reducer'
 import { Channel, ChannelBrowser, AllDms, People } from './template'
@@ -15,13 +18,22 @@ interface MatchParamsType {
 }
 
 const WorkspacePage = () => {
-  const { channelList } = useSelector((state: RootState) => state.channelStore)
-  const { currentWorkspace } = useSelector(
-    (state: RootState) => state.workspaceStore,
-  )
-
   const dispatch = useDispatch()
   const { workspaceId } = useParams<MatchParamsType>()
+  const { channelList } = useSelector((state: RootState) => state.channelStore)
+  const { workspaceList, currentWorkspace } = useSelector(
+    (state: RootState) => {
+      return {
+        workspaceList: state.workspaceStore.workspaceList,
+        currentWorkspace: state.workspaceStore.currentWorkspace,
+      }
+    },
+  )
+  useEffect(() => {
+    dispatch(connectSocket.request({ workspaceId: +workspaceId }))
+    dispatch(getCurrentWorkspaceInfo.request({ id: +workspaceId }))
+    dispatch(getWorkspace.request())
+  }, [])
 
   const [subViewShow, setSubViewShow] = useState(false)
   const [subViewHeader, setSubViewHeader] = useState<React.ReactNode>(<></>)
@@ -35,16 +47,15 @@ const WorkspacePage = () => {
   const handleSubViewHeader = (node: React.ReactNode) => setSubViewHeader(node)
   const handleSubViewBody = (node: React.ReactNode) => setSubViewBody(node)
 
-  useEffect(() => {
-    dispatch(connectSocket.request({ workspaceId: +workspaceId }))
-    dispatch(getCurrentWorkspaceInfo.request({ id: +workspaceId }))
-  }, [])
-
   return (
     <WorkspaceContainer>
       <O.Header />
 
       <WorkspaceLayout>
+        <O.WorkspaceSideBar
+          workspaceList={workspaceList}
+          currentWorkspaceId={currentWorkspace.id}
+        />
         <O.SideBar workspaceInfo={currentWorkspace} channelList={channelList} />
 
         <ViewContainer>
@@ -99,7 +110,7 @@ const WorkspaceContainer = styled.div`
 const WorkspaceLayout = styled.div`
   display: grid;
   grid-template-rows: auto;
-  grid-template-columns: 230px auto;
+  grid-template-columns: 65px 230px auto;
 `
 
 const ViewContainer = styled.div`


### PR DESCRIPTION
## Linked Issue
close #235 

## 공유할 사항 
- WorkspacePage에서 workspace 이동 가능하도록 왼쪽 사이드바에 workspace list sidebar 추가
- 현재 사이드바 상단에 있는 workspace image 제거
- workspace list 가장 하단의 + 버튼 클릭 시 /workspace/new 페이지로 이동

<img width="233" alt="스크린샷 2020-12-15 오후 4 27 03" src="https://user-images.githubusercontent.com/57661699/102185351-470e6480-3ef4-11eb-9d0e-0a51e07deec6.png">

## 논의할 사항 
- 
