### PR TITLE
Add home button in WorkspaceSideBar

### DIFF
--- a/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
+++ b/client/src/component/organism/WorkspaceSideBar/WorkspaceSideBar.tsx
@@ -19,9 +19,15 @@ const WorkspaceSideBar = ({
   const handleAddWorkspaceButtonClick = () => {
     history.push('/workspace/new')
   }
+  const handleHomeButtonClick = () => {
+    window.location.href = `/`
+  }
 
   return (
     <Styled.Wrapper>
+      <A.Button customStyle={homeButtonStyle} onClick={handleHomeButtonClick}>
+        <A.Icon icon={myIcon.home} customStyle={{ fontSize: '1.6rem' }} />
+      </A.Button>
       {workspaceList.map((workspace) => {
         return workspace.id === currentWorkspaceId ? (
           <Styled.CurrentWorkspaceImageWrapper key={workspace.id}>
@@ -58,6 +64,15 @@ const plusButtonStyle: ButtonType.StyleAttributes = {
   borderRadius: '8px',
   padding: '2px',
   margin: '10px 0',
+}
+const homeButtonStyle: ButtonType.StyleAttributes = {
+  hoverBackgroundColor: 'greyHover',
+  width: '45px',
+  height: '45px',
+  borderRadius: '7px',
+  padding: '2px',
+  margin: '10px 0 5px 0',
+  border: '1px solid lightgrey',
 }
 
 export default WorkspaceSideBar

--- a/client/src/constant/icon.ts
+++ b/client/src/constant/icon.ts
@@ -29,6 +29,7 @@ import {
   faPaperclip,
   faCheck,
   faArrowRight,
+  faHome,
 } from '@fortawesome/free-solid-svg-icons'
 
 const myIcon = {
@@ -62,6 +63,7 @@ const myIcon = {
   paperClip: faPaperclip,
   check: faCheck,
   rightArrow: faArrowRight,
+  home: faHome,
 }
 
 export default myIcon


### PR DESCRIPTION
## Linked Issue
close #

## 공유할 사항 
- Workspace 사이드바에 home 버튼 추가
  - 클릭시 slack 메인 화면으로 이동
<img width="586" alt="스크린샷 2020-12-15 오후 6 14 24" src="https://user-images.githubusercontent.com/57661699/102195071-74154400-3f01-11eb-8fb7-aa3f52cda01b.png">


## 논의할 사항 
- 
