### PR TITLE
Reaction tooltip 구현

### DIFF
--- a/client/src/component/molecule/ReactionButton/ReactionButton.style.ts
+++ b/client/src/component/molecule/ReactionButton/ReactionButton.style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+
+const TooltipContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 6px;
+  max-width: 300px;
+  text-align: center;
+`
+
+export default {
+  TooltipContent,
+}

--- a/client/src/component/molecule/ReactionButton/ReactionButton.tsx
+++ b/client/src/component/molecule/ReactionButton/ReactionButton.tsx
@@ -1,15 +1,21 @@
-import React from 'react'
+import React, { useState, useRef } from 'react'
 import A from '@atom'
+import M from '@molecule'
 import { ButtonType } from '@atom/Button'
 import { TextType } from '@atom/Text'
 import { Emoji } from 'emoji-mart'
 import { ReactionButtonProps } from '.'
+import Styled from './ReactionButton.style'
 
 const ReactionButton = ({
   reactionBundle,
   loginUserId,
   onReactionClick,
 }: ReactionButtonProps) => {
+  const [hover, setHover] = useState<boolean>(false)
+  const handleMouseEnter = () => setHover(true)
+  const handleMouseLeave = () => setHover(false)
+
   const emoji = reactionBundle[0]?.content
   const reacted = !!reactionBundle.find(
     (reaction) => reaction.User.id === loginUserId,
@@ -23,19 +29,44 @@ const ReactionButton = ({
     onReactionClick(emoji)
   }
 
+  const reactionEl = useRef<HTMLDivElement>(null)
+
+  const tooltipContent = (
+    <Styled.TooltipContent>
+      <Emoji emoji={emoji} size={25} />
+      <A.Text customStyle={tooltipNameTextStyle}>
+        {reactionBundle
+          .reduce((prev, reaction) => `${prev + reaction.User.name}, `, '')
+          .slice(0, -2)}
+      </A.Text>
+      <A.Text customStyle={tooltipDescTextStyle}>
+        {`reacted with ${emoji}`}
+      </A.Text>
+    </Styled.TooltipContent>
+  )
+
   return (
-    <A.Button
-      customStyle={{
-        ...defaultButtonStyle,
-        ...switchButtonStyle,
-      }}
-      onClick={handleReactionClick}
-    >
-      <>
-        <Emoji emoji={emoji} size={16} />
-        <A.Text customStyle={textStyle}>{reactionBundle.length}</A.Text>
-      </>
-    </A.Button>
+    <>
+      <div
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        ref={reactionEl}
+      >
+        <A.Button
+          customStyle={{
+            ...defaultButtonStyle,
+            ...switchButtonStyle,
+          }}
+          onClick={handleReactionClick}
+        >
+          <>
+            <Emoji emoji={emoji} size={16} />
+            <A.Text customStyle={textStyle}>{reactionBundle.length}</A.Text>
+          </>
+        </A.Button>
+      </div>
+      {hover && <M.Tooltip parent={reactionEl} content={tooltipContent} />}
+    </>
   )
 }
 
@@ -60,6 +91,20 @@ const unreactedButtonStyle: ButtonType.StyleAttributes = {
 const textStyle: TextType.StyleAttributes = {
   fontSize: '1.2rem',
   margin: '0 0 0 7px',
+}
+
+const tooltipNameTextStyle: TextType.StyleAttributes = {
+  fontSize: '1.3rem',
+  fontWeight: '600',
+  color: 'white',
+  margin: '5px 0 0 0',
+}
+
+const tooltipDescTextStyle: TextType.StyleAttributes = {
+  fontSize: '1.3rem',
+  fontWeight: '600',
+  color: 'darkGrey',
+  margin: '3px 0 0 0',
 }
 
 export default ReactionButton

--- a/client/src/component/molecule/ReactionButton/ReactionButton.tsx
+++ b/client/src/component/molecule/ReactionButton/ReactionButton.tsx
@@ -35,9 +35,18 @@ const ReactionButton = ({
     <Styled.TooltipContent>
       <Emoji emoji={emoji} size={25} />
       <A.Text customStyle={tooltipNameTextStyle}>
-        {reactionBundle
-          .reduce((prev, reaction) => `${prev + reaction.User.name}, `, '')
-          .slice(0, -2)}
+        {reactionBundle.length === 1 &&
+        reactionBundle[0].User.id === loginUserId
+          ? 'You (click to remove)'
+          : reactionBundle
+              .reduce((prev, reaction, idx, arr) => {
+                const user = reaction.User
+                if (user.id !== loginUserId) return `${prev}${user.name}, `
+                if (idx === 0) return `You and `
+                if (idx === arr.length - 1) return `${prev} and you  `
+                return `${prev}you, `
+              }, '')
+              .slice(0, -2)}
       </A.Text>
       <A.Text customStyle={tooltipDescTextStyle}>
         {`reacted with ${emoji}`}

--- a/client/src/component/molecule/Tooltip/Tooltip.style.ts
+++ b/client/src/component/molecule/Tooltip/Tooltip.style.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div<{ bottom: number; left: number }>`
+  width: fit-content;
+  height: fit-content;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px;
+  overflow: hidden;
+  border: 1px solid rgba(97, 96, 97, 0.13);
+  border-radius: 6px;
+  background-color: black;
+  color: white;
+  position: fixed;
+  bottom: ${({ bottom }) => bottom}px;
+  left: ${({ left }) => left}px;
+  z-index: 100;
+`
+
+export default {
+  Wrapper,
+}

--- a/client/src/component/molecule/Tooltip/Tooltip.style.ts
+++ b/client/src/component/molecule/Tooltip/Tooltip.style.ts
@@ -1,23 +1,39 @@
 import styled from 'styled-components'
 
 const Wrapper = styled.div<{ bottom: number; left: number }>`
-  width: fit-content;
-  height: fit-content;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 4px;
-  overflow: hidden;
-  border: 1px solid rgba(97, 96, 97, 0.13);
-  border-radius: 6px;
-  background-color: black;
-  color: white;
   position: fixed;
   bottom: ${({ bottom }) => bottom}px;
   left: ${({ left }) => left}px;
   z-index: 100;
+  display: flex;
+`
+
+const Box = styled.div`
+  width: fit-content;
+  height: fit-content;
+  justify-content: center;
+  align-items: center;
+  padding: 4px;
+  border: 1px solid rgba(97, 96, 97, 0.13);
+  border-radius: 6px;
+  background-color: black;
+  &::after {
+    position: absolute;
+    content: ' ';
+    height: 0;
+    z-index: -1;
+    border-bottom: 12px solid;
+    border-left: 10px solid rgba(0, 0, 0, 0);
+    border-right: 10px solid rgba(0, 0, 0, 0);
+    transform: rotate(-180deg);
+    -webkit-transform: rotate(-180deg);
+    -moz-transform: rotate(-180deg);
+    -o-transform: rotate(-180deg);
+    -ms-transform: rotate(-180deg);
+  }
 `
 
 export default {
   Wrapper,
+  Box,
 }

--- a/client/src/component/molecule/Tooltip/Tooltip.tsx
+++ b/client/src/component/molecule/Tooltip/Tooltip.tsx
@@ -6,11 +6,11 @@ const Tooltip = ({ position, content, parent }: TooltipProps) => {
   const parentEl = (parent.current as HTMLElement).getBoundingClientRect()
   const { x, y } = parentEl
   const wHeight = window.innerHeight
-  const tooltipBottom = wHeight - y + 5
+  const tooltipBottom = wHeight - y + 10
   const tooltipLeft = x
   return (
     <Styled.Wrapper bottom={tooltipBottom} left={tooltipLeft}>
-      {content}
+      <Styled.Box>{content}</Styled.Box>
     </Styled.Wrapper>
   )
 }

--- a/client/src/component/molecule/Tooltip/Tooltip.tsx
+++ b/client/src/component/molecule/Tooltip/Tooltip.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { TooltipProps } from '.'
+import Styled from './Tooltip.style'
+
+const Tooltip = ({ position, content, parent }: TooltipProps) => {
+  const parentEl = (parent.current as HTMLElement).getBoundingClientRect()
+  const { x, y } = parentEl
+  const wHeight = window.innerHeight
+  const tooltipBottom = wHeight - y + 5
+  const tooltipLeft = x
+  return (
+    <Styled.Wrapper bottom={tooltipBottom} left={tooltipLeft}>
+      {content}
+    </Styled.Wrapper>
+  )
+}
+
+export default Tooltip

--- a/client/src/component/molecule/Tooltip/index.ts
+++ b/client/src/component/molecule/Tooltip/index.ts
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export { default } from './Tooltip'
+
+export interface TooltipProps {
+  position?: 'TOP' | 'BOTTOM' | 'LEFT' | 'RIGHT'
+  content: React.ReactElement
+  parent: React.RefObject<HTMLDivElement>
+}

--- a/client/src/component/molecule/index.ts
+++ b/client/src/component/molecule/index.ts
@@ -11,6 +11,7 @@ import SelectableTeammate from './SelectableTeammate'
 import SendEmailModal from './SendEmailModal'
 import CreateModal from './CreateModal'
 import DayDivider from './DayDivider'
+import Tooltip from './Tooltip'
 
 export default {
   ButtonDiv,
@@ -26,4 +27,5 @@ export default {
   SendEmailModal,
   CreateModal,
   DayDivider,
+  Tooltip,
 }

--- a/client/src/component/organism/ReactionList/ReactionList.tsx
+++ b/client/src/component/organism/ReactionList/ReactionList.tsx
@@ -5,22 +5,9 @@ import O from '@organism'
 import { ButtonType } from '@atom/Button'
 import myIcon from '@constant/icon'
 import calcModalPosition from '@util/calcModalPosition'
-import { ReactionListProps } from '.'
+import { ReactionListProps, ReactionType } from '.'
 
 import Styled from './ReactionList.style'
-
-interface ReactionType {
-  id: number
-  content: string
-  User: UserType
-}
-
-interface UserType {
-  id: number
-  email: string
-  name: string
-  profileImageUrl: string
-}
 
 const ReactionList = ({
   reactionArr,

--- a/client/src/component/organism/ReactionList/index.ts
+++ b/client/src/component/organism/ReactionList/index.ts
@@ -1,3 +1,5 @@
+import { UserType } from '@type/user.type'
+
 export { default } from './ReactionList'
 
 export interface ReactionListProps {
@@ -6,15 +8,8 @@ export interface ReactionListProps {
   onReactionClick: (emoji: string) => void
 }
 
-interface ReactionType {
+export interface ReactionType {
   id: number
   content: string
   User: UserType
-}
-
-interface UserType {
-  id: number
-  email: string
-  name: string
-  profileImageUrl: string
 }


### PR DESCRIPTION
## Linked Issue
close #

## 공유할 사항 
- Tooltip molecule 구현
- ReactioinButton에 툴팁 사용
  - Reaction button hover 시 tooltip으로 reaction 한 user name list와 reaction emoji의 CLDR이 표시됨
<img width="603" alt="스크린샷 2020-12-19 오후 6 56 09" src="https://user-images.githubusercontent.com/57661699/102686577-fc5e5680-422b-11eb-8cfd-06caae0fe520.png">

## 논의할 사항 
- 
